### PR TITLE
Chart Version Control

### DIFF
--- a/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/factories/KubernetesObjectFactory.java
+++ b/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/factories/KubernetesObjectFactory.java
@@ -215,6 +215,7 @@ public class KubernetesObjectFactory implements IKubernetesObjectFactory {
                 gaffer.getMetadata().getName(),
                 GAFFER,
                 REPO_ARG, helmRepo,
+                VERSION_ARG, chartVersion,
                 VALUES_ARG, VALUES_YAML_LOCATION,
                 NAMESPACE_ARG, gaffer.getMetadata().getNamespace());
         if (openshiftEnabled) {


### PR DESCRIPTION
Tiny change in order to rectify #268 

Also looked into #269 - it seems to have been completed. Can we consider it as a closed issue?
`revision` and `gaffer.version` are now in sync and there is only 1 `gaffer.version` declared now which is declared in the main POM and then inherited by all the child POMs. There is also no more reference to `gaas-common`.