### PR TITLE
Gh 306 /what-auth endpoint

### DIFF
--- a/gaffer-as-a-service/gaas-jwt-sidecar/src/main/java/uk/gov/gchq/gaffer/gaas/sidecar/controller/CustomFilter.java
+++ b/gaffer-as-a-service/gaas-jwt-sidecar/src/main/java/uk/gov/gchq/gaffer/gaas/sidecar/controller/CustomFilter.java
@@ -47,7 +47,7 @@ public class CustomFilter implements GlobalFilter {
     @Override
     public Mono<Void> filter(final ServerWebExchange exchange, final GatewayFilterChain chain) {
         ServerHttpRequest request = exchange.getRequest();
-        if (request.getPath().toString().equals("/auth")) {
+        if (request.getPath().toString().equals("/auth") || request.getPath().toString().equals("/what-auth")) {
             return chain.filter(exchange).then(Mono.fromRunnable(() -> {
                 ServerHttpResponse response = exchange.getResponse();
                 logger.info("Post Filter = " + response.getStatusCode());

--- a/gaffer-as-a-service/gaas-jwt-sidecar/src/main/java/uk/gov/gchq/gaffer/gaas/sidecar/controller/SidecarController.java
+++ b/gaffer-as-a-service/gaas-jwt-sidecar/src/main/java/uk/gov/gchq/gaffer/gaas/sidecar/controller/SidecarController.java
@@ -55,13 +55,14 @@ public class SidecarController {
     }
 
     @GetMapping(path = "/what-auth", produces = "application/json")
-    public ResponseEntity<List<WhatAuthResponse>> getWhatAuth() {
+    public ResponseEntity<WhatAuthResponse> getWhatAuth() {
+        Map<String, String> attributes = new HashMap<>();
         Map<String, String> requiredHeaders = new HashMap<>();
         requiredHeaders.put("Authorization", "Bearer");
         ArrayList requiredFields = new ArrayList();
         requiredFields.add("username");
         requiredFields.add("password");
-        WhatAuthResponse body = new WhatAuthResponse(new HashMap<>(), requiredFields, requiredHeaders);
+        WhatAuthResponse body = new WhatAuthResponse(attributes, requiredFields, requiredHeaders);
         return new ResponseEntity(body, HttpStatus.OK);
     }
 

--- a/gaffer-as-a-service/gaas-jwt-sidecar/src/main/java/uk/gov/gchq/gaffer/gaas/sidecar/controller/SidecarController.java
+++ b/gaffer-as-a-service/gaas-jwt-sidecar/src/main/java/uk/gov/gchq/gaffer/gaas/sidecar/controller/SidecarController.java
@@ -17,14 +17,24 @@
 package uk.gov.gchq.gaffer.gaas.sidecar.controller;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.gchq.gaffer.gaas.sidecar.auth.JwtRequest;
+import uk.gov.gchq.gaffer.gaas.sidecar.models.WhatAuthResponse;
 import uk.gov.gchq.gaffer.gaas.sidecar.services.AuthService;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @Component
 @CrossOrigin
@@ -42,6 +52,17 @@ public class SidecarController {
         } catch (Exception e) {
             return ResponseEntity.status(401).body("Invalid credentials");
         }
+    }
+
+    @GetMapping(path = "/what-auth", produces = "application/json")
+    public ResponseEntity<List<WhatAuthResponse>> getWhatAuth() {
+        Map<String, String> requiredHeaders = new HashMap<>();
+        requiredHeaders.put("Authorization", "Bearer");
+        ArrayList requiredFields = new ArrayList();
+        requiredFields.add("username");
+        requiredFields.add("password");
+        WhatAuthResponse body = new WhatAuthResponse(new HashMap<>(), requiredFields, requiredHeaders);
+        return new ResponseEntity(body, HttpStatus.OK);
     }
 
 }

--- a/gaffer-as-a-service/gaas-jwt-sidecar/src/main/java/uk/gov/gchq/gaffer/gaas/sidecar/controller/SidecarController.java
+++ b/gaffer-as-a-service/gaas-jwt-sidecar/src/main/java/uk/gov/gchq/gaffer/gaas/sidecar/controller/SidecarController.java
@@ -70,7 +70,12 @@ public class SidecarController {
 
     @GetMapping(path = "/whoami", produces = "application/json")
     ResponseEntity<String> whoami(@RequestHeader final HttpHeaders headers) {
-        String username = jwtTokenUtil.getUsernameFromToken(headers.get("Authorization").get(0).substring(7));
+        String username = "";
+        try {
+            username = jwtTokenUtil.getUsernameFromToken(headers.get("Authorization").get(0).substring(7));
+        } catch (Exception e) {
+            return new ResponseEntity<>("Error resolving Authorization header", HttpStatus.BAD_REQUEST);
+        }
         return new ResponseEntity<>(username, HttpStatus.OK);
     }
 

--- a/gaffer-as-a-service/gaas-jwt-sidecar/src/main/java/uk/gov/gchq/gaffer/gaas/sidecar/controller/SidecarController.java
+++ b/gaffer-as-a-service/gaas-jwt-sidecar/src/main/java/uk/gov/gchq/gaffer/gaas/sidecar/controller/SidecarController.java
@@ -17,6 +17,7 @@
 package uk.gov.gchq.gaffer.gaas.sidecar.controller;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
@@ -24,8 +25,10 @@ import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.gchq.gaffer.gaas.sidecar.auth.JwtRequest;
+import uk.gov.gchq.gaffer.gaas.sidecar.auth.JwtTokenUtil;
 import uk.gov.gchq.gaffer.gaas.sidecar.models.WhatAuthResponse;
 import uk.gov.gchq.gaffer.gaas.sidecar.services.AuthService;
 
@@ -40,6 +43,8 @@ public class SidecarController {
 
     @Autowired
     private AuthService authService;
+    @Autowired
+    private JwtTokenUtil jwtTokenUtil;
 
     @PostMapping("/auth")
     public ResponseEntity<String> createAuthenticationToken(@RequestBody final JwtRequest authenticationRequest) throws Exception {
@@ -61,6 +66,12 @@ public class SidecarController {
         requiredFields.add("password");
         WhatAuthResponse body = new WhatAuthResponse(attributes, requiredFields, requiredHeaders);
         return new ResponseEntity(body, HttpStatus.OK);
+    }
+
+    @GetMapping(path = "/whoami", produces = "application/json")
+    ResponseEntity<String> whoami(@RequestHeader final HttpHeaders headers) {
+        String username = jwtTokenUtil.getUsernameFromToken(headers.get("Authorization").get(0).substring(7));
+        return new ResponseEntity<>(username, HttpStatus.OK);
     }
 
 }

--- a/gaffer-as-a-service/gaas-jwt-sidecar/src/main/java/uk/gov/gchq/gaffer/gaas/sidecar/controller/SidecarController.java
+++ b/gaffer-as-a-service/gaas-jwt-sidecar/src/main/java/uk/gov/gchq/gaffer/gaas/sidecar/controller/SidecarController.java
@@ -17,7 +17,6 @@
 package uk.gov.gchq.gaffer.gaas.sidecar.controller;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
@@ -25,7 +24,6 @@ import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.gchq.gaffer.gaas.sidecar.auth.JwtRequest;
 import uk.gov.gchq.gaffer.gaas.sidecar.models.WhatAuthResponse;
@@ -33,7 +31,6 @@ import uk.gov.gchq.gaffer.gaas.sidecar.services.AuthService;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 @Component

--- a/gaffer-as-a-service/gaas-jwt-sidecar/src/main/java/uk/gov/gchq/gaffer/gaas/sidecar/models/WhatAuthResponse.java
+++ b/gaffer-as-a-service/gaas-jwt-sidecar/src/main/java/uk/gov/gchq/gaffer/gaas/sidecar/models/WhatAuthResponse.java
@@ -1,0 +1,42 @@
+package uk.gov.gchq.gaffer.gaas.sidecar.models;
+
+import java.util.ArrayList;
+import java.util.Map;
+
+public class WhatAuthResponse {
+    public WhatAuthResponse(Map<String,String> attributes, ArrayList<String> requiredFields, Map<String, String> requiredHeaders){
+        this.attributes = attributes;
+        this.requiredFields = requiredFields;
+        this.requiredHeaders = requiredHeaders;
+    }
+
+    public Map<String, String> getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(Map<String, String> attributes) {
+        this.attributes = attributes;
+    }
+
+    public ArrayList<String> getRequiredFields() {
+        return requiredFields;
+    }
+
+    public void setRequiredFields(ArrayList<String> requiredFields) {
+        this.requiredFields = requiredFields;
+    }
+
+    public Map<String, String> getRequiredHeaders() {
+        return requiredHeaders;
+    }
+
+    public void setRequiredHeaders(Map<String, String> requiredHeaders) {
+        this.requiredHeaders = requiredHeaders;
+    }
+
+    private Map<String, String> attributes;
+    private ArrayList<String> requiredFields;
+    private Map<String,String> requiredHeaders;
+
+
+}

--- a/gaffer-as-a-service/gaas-jwt-sidecar/src/main/java/uk/gov/gchq/gaffer/gaas/sidecar/models/WhatAuthResponse.java
+++ b/gaffer-as-a-service/gaas-jwt-sidecar/src/main/java/uk/gov/gchq/gaffer/gaas/sidecar/models/WhatAuthResponse.java
@@ -1,10 +1,26 @@
+/*
+ * Copyright 2022 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.gchq.gaffer.gaas.sidecar.models;
 
 import java.util.ArrayList;
 import java.util.Map;
 
 public class WhatAuthResponse {
-    public WhatAuthResponse(Map<String,String> attributes, ArrayList<String> requiredFields, Map<String, String> requiredHeaders){
+    public WhatAuthResponse(final Map<String, String> attributes, final ArrayList<String> requiredFields, final Map<String, String> requiredHeaders) {
         this.attributes = attributes;
         this.requiredFields = requiredFields;
         this.requiredHeaders = requiredHeaders;
@@ -14,7 +30,7 @@ public class WhatAuthResponse {
         return attributes;
     }
 
-    public void setAttributes(Map<String, String> attributes) {
+    public void setAttributes(final Map<String, String> attributes) {
         this.attributes = attributes;
     }
 
@@ -22,7 +38,7 @@ public class WhatAuthResponse {
         return requiredFields;
     }
 
-    public void setRequiredFields(ArrayList<String> requiredFields) {
+    public void setRequiredFields(final ArrayList<String> requiredFields) {
         this.requiredFields = requiredFields;
     }
 
@@ -30,13 +46,13 @@ public class WhatAuthResponse {
         return requiredHeaders;
     }
 
-    public void setRequiredHeaders(Map<String, String> requiredHeaders) {
+    public void setRequiredHeaders(final Map<String, String> requiredHeaders) {
         this.requiredHeaders = requiredHeaders;
     }
 
     private Map<String, String> attributes;
     private ArrayList<String> requiredFields;
-    private Map<String,String> requiredHeaders;
+    private Map<String, String> requiredHeaders;
 
 
 }

--- a/gaffer-as-a-service/gaas-jwt-sidecar/src/test/java/uk/gov/gchq/gaffer/gaas/sidecar/controller/SidecarControllerTest.java
+++ b/gaffer-as-a-service/gaas-jwt-sidecar/src/test/java/uk/gov/gchq/gaffer/gaas/sidecar/controller/SidecarControllerTest.java
@@ -24,6 +24,8 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.web.reactive.function.BodyInserters;
 import uk.gov.gchq.gaffer.gaas.sidecar.util.UnitTest;
 
+import java.util.concurrent.atomic.AtomicReference;
+
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -58,14 +60,44 @@ public class SidecarControllerTest {
     @Test
     void whatAuthShouldReturnWhatAuthInformationWhenSuccess() {
         String expected = "{\"attributes\":{},\"requiredFields\":[\"username\",\"password\"],\"requiredHeaders\":{\"Authorization\":\"Bearer\"}}";
-        WebTestClient.BodyContentSpec response = webClient.get()
+        webClient.get()
                 .uri("/what-auth")
                 .exchange()
                 .expectStatus().is2xxSuccessful()
                 .expectBody().consumeWith(res -> {
-                    final String body = new String(res.getResponseBody(), UTF_8);
+            final String body = new String(res.getResponseBody(), UTF_8);
 
-                    assertEquals(expected, body);
-                });
+            assertEquals(expected, body);
+        });
     }
+
+    @Test
+    void getWhoAmIShouldReturnUsernameWhenSuccessful() {
+
+        final String authRequest = "{\"username\":\"javainuse\",\"password\":\"password\"}";
+        AtomicReference<String> token = new AtomicReference<>();
+        webClient.post()
+                .uri("/auth")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(BodyInserters.fromObject(authRequest))
+                .exchange()
+                .expectStatus().is2xxSuccessful()
+                .expectBody().consumeWith(res -> {
+            token.set(new String(res.getResponseBody(), UTF_8));
+
+    });
+
+        String expected = "javainuse";
+        webClient.get()
+                .uri("/whoami")
+                .header("Authorization", "Bearer " + token)
+                .exchange()
+                .expectStatus().is2xxSuccessful()
+                .expectBody().consumeWith(res -> {
+            final String body = new String(res.getResponseBody(), UTF_8);
+
+            assertEquals(expected, body);
+        });
+    }
+    
 }

--- a/gaffer-as-a-service/gaas-jwt-sidecar/src/test/java/uk/gov/gchq/gaffer/gaas/sidecar/controller/SidecarControllerTest.java
+++ b/gaffer-as-a-service/gaas-jwt-sidecar/src/test/java/uk/gov/gchq/gaffer/gaas/sidecar/controller/SidecarControllerTest.java
@@ -24,6 +24,9 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.web.reactive.function.BodyInserters;
 import uk.gov.gchq.gaffer.gaas.sidecar.util.UnitTest;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 @WebFluxTest(controllers = SidecarController.class)
 @UnitTest
 public class SidecarControllerTest {
@@ -50,5 +53,20 @@ public class SidecarControllerTest {
                 .body(BodyInserters.fromObject(authRequest))
                 .exchange()
                 .expectStatus().isUnauthorized();
+    }
+
+    @Test
+    void whatAuthShouldReturnObjectWhenSuccess() throws Exception {
+        String expected = "{\"attributes\":{},\"requiredFields\":[\"username\",\"password\"],\"requiredHeaders\":{\"Authorization\":\"Bearer\"}}";
+        WebTestClient.BodyContentSpec response = webClient.get()
+                .uri("/what-auth")
+                .header("x-email", "mytest@email.com")
+                .exchange()
+                .expectStatus().is2xxSuccessful()
+                .expectBody().consumeWith(res -> {
+                    final String body = new String(res.getResponseBody(), UTF_8);
+
+                    assertEquals(expected, body);
+                });
     }
 }

--- a/gaffer-as-a-service/gaas-jwt-sidecar/src/test/java/uk/gov/gchq/gaffer/gaas/sidecar/controller/SidecarControllerTest.java
+++ b/gaffer-as-a-service/gaas-jwt-sidecar/src/test/java/uk/gov/gchq/gaffer/gaas/sidecar/controller/SidecarControllerTest.java
@@ -60,7 +60,6 @@ public class SidecarControllerTest {
         String expected = "{\"attributes\":{},\"requiredFields\":[\"username\",\"password\"],\"requiredHeaders\":{\"Authorization\":\"Bearer\"}}";
         WebTestClient.BodyContentSpec response = webClient.get()
                 .uri("/what-auth")
-                .header("x-email", "mytest@email.com")
                 .exchange()
                 .expectStatus().is2xxSuccessful()
                 .expectBody().consumeWith(res -> {

--- a/gaffer-as-a-service/gaas-jwt-sidecar/src/test/java/uk/gov/gchq/gaffer/gaas/sidecar/controller/SidecarControllerTest.java
+++ b/gaffer-as-a-service/gaas-jwt-sidecar/src/test/java/uk/gov/gchq/gaffer/gaas/sidecar/controller/SidecarControllerTest.java
@@ -99,5 +99,32 @@ public class SidecarControllerTest {
             assertEquals(expected, body);
         });
     }
-    
+
+    @Test
+    void getWhoAmIShouldThrowBadRequestErrorWhenTokenMissing() {
+        String expected = "Error resolving Authorization header";
+        webClient.get()
+                .uri("/whoami")
+                .header("Authorization", "Bearer ")
+                .exchange()
+                .expectStatus().is4xxClientError()
+                .expectBody().consumeWith(res -> {
+            final String body = new String(res.getResponseBody(), UTF_8);
+
+            assertEquals(expected, body);
+        });
+    }
+    @Test
+    void getWhoAmIShouldThrowBadRequestErrorWhenHeaderMissing() {
+        String expected = "Error resolving Authorization header";
+        webClient.get()
+                .uri("/whoami")
+                .exchange()
+                .expectStatus().is4xxClientError()
+                .expectBody().consumeWith(res -> {
+            final String body = new String(res.getResponseBody(), UTF_8);
+
+            assertEquals(expected, body);
+        });
+    }
 }

--- a/gaffer-as-a-service/gaas-jwt-sidecar/src/test/java/uk/gov/gchq/gaffer/gaas/sidecar/controller/SidecarControllerTest.java
+++ b/gaffer-as-a-service/gaas-jwt-sidecar/src/test/java/uk/gov/gchq/gaffer/gaas/sidecar/controller/SidecarControllerTest.java
@@ -56,7 +56,7 @@ public class SidecarControllerTest {
     }
 
     @Test
-    void whatAuthShouldReturnObjectWhenSuccess() throws Exception {
+    void whatAuthShouldReturnWhatAuthInformationWhenSuccess() {
         String expected = "{\"attributes\":{},\"requiredFields\":[\"username\",\"password\"],\"requiredHeaders\":{\"Authorization\":\"Bearer\"}}";
         WebTestClient.BodyContentSpec response = webClient.get()
                 .uri("/what-auth")

--- a/gaffer-as-a-service/gaas-openshift-sidecar/src/main/java/uk/gov/gchq/gaffer/gaas/sidecar/controller/CustomFilter.java
+++ b/gaffer-as-a-service/gaas-openshift-sidecar/src/main/java/uk/gov/gchq/gaffer/gaas/sidecar/controller/CustomFilter.java
@@ -27,6 +27,7 @@ import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
+
 @Order(2)
 @Configuration
 public class CustomFilter implements GlobalFilter {
@@ -37,6 +38,10 @@ public class CustomFilter implements GlobalFilter {
     public Mono<Void> filter(final ServerWebExchange exchange, final GatewayFilterChain chain) {
 
         ServerHttpRequest request = exchange.getRequest();
+        if (request.getPath().toString().equals("/what-auth")) {
+            ServerHttpResponse response = exchange.getResponse();
+            logger.info("Post Filter = " + response.getStatusCode());
+        }
         if (request.getHeaders().getFirst("x-email") != null) {
             return chain.filter(exchange).then(Mono.fromRunnable(() -> {
                 ServerHttpResponse response = exchange.getResponse();

--- a/gaffer-as-a-service/gaas-openshift-sidecar/src/main/java/uk/gov/gchq/gaffer/gaas/sidecar/controller/SidecarController.java
+++ b/gaffer-as-a-service/gaas-openshift-sidecar/src/main/java/uk/gov/gchq/gaffer/gaas/sidecar/controller/SidecarController.java
@@ -23,6 +23,11 @@ import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
+import uk.gov.gchq.gaffer.gaas.sidecar.models.WhatAuthResponse;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 @Component
 @CrossOrigin
@@ -31,5 +36,14 @@ public class SidecarController {
     @GetMapping(path = "/whoami", produces = "application/json")
     ResponseEntity<String> whoami(@RequestHeader("x-email") final String email) {
         return new ResponseEntity<>(email, HttpStatus.OK);
+    }
+    @GetMapping(path = "/what-auth", produces = "application/json")
+    public ResponseEntity<WhatAuthResponse> getWhatAuth() {
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put("withCredentials", "true");
+        Map<String, String> requiredHeaders = new HashMap<>();
+        ArrayList requiredFields = new ArrayList();
+        WhatAuthResponse body = new WhatAuthResponse(attributes, requiredFields, requiredHeaders);
+        return new ResponseEntity(body, HttpStatus.OK);
     }
 }

--- a/gaffer-as-a-service/gaas-openshift-sidecar/src/main/java/uk/gov/gchq/gaffer/gaas/sidecar/models/WhatAuthResponse.java
+++ b/gaffer-as-a-service/gaas-openshift-sidecar/src/main/java/uk/gov/gchq/gaffer/gaas/sidecar/models/WhatAuthResponse.java
@@ -1,0 +1,42 @@
+package uk.gov.gchq.gaffer.gaas.sidecar.models;
+
+import java.util.ArrayList;
+import java.util.Map;
+
+public class WhatAuthResponse {
+    public WhatAuthResponse(Map<String,String> attributes, ArrayList<String> requiredFields, Map<String, String> requiredHeaders){
+        this.attributes = attributes;
+        this.requiredFields = requiredFields;
+        this.requiredHeaders = requiredHeaders;
+    }
+
+    public Map<String, String> getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(Map<String, String> attributes) {
+        this.attributes = attributes;
+    }
+
+    public ArrayList<String> getRequiredFields() {
+        return requiredFields;
+    }
+
+    public void setRequiredFields(ArrayList<String> requiredFields) {
+        this.requiredFields = requiredFields;
+    }
+
+    public Map<String, String> getRequiredHeaders() {
+        return requiredHeaders;
+    }
+
+    public void setRequiredHeaders(Map<String, String> requiredHeaders) {
+        this.requiredHeaders = requiredHeaders;
+    }
+
+    private Map<String, String> attributes;
+    private ArrayList<String> requiredFields;
+    private Map<String,String> requiredHeaders;
+
+
+}

--- a/gaffer-as-a-service/gaas-openshift-sidecar/src/main/java/uk/gov/gchq/gaffer/gaas/sidecar/models/WhatAuthResponse.java
+++ b/gaffer-as-a-service/gaas-openshift-sidecar/src/main/java/uk/gov/gchq/gaffer/gaas/sidecar/models/WhatAuthResponse.java
@@ -1,10 +1,26 @@
+/*
+ * Copyright 2022 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.gchq.gaffer.gaas.sidecar.models;
 
 import java.util.ArrayList;
 import java.util.Map;
 
 public class WhatAuthResponse {
-    public WhatAuthResponse(Map<String,String> attributes, ArrayList<String> requiredFields, Map<String, String> requiredHeaders){
+    public WhatAuthResponse(final Map<String, String> attributes, final ArrayList<String> requiredFields, final Map<String, String> requiredHeaders) {
         this.attributes = attributes;
         this.requiredFields = requiredFields;
         this.requiredHeaders = requiredHeaders;
@@ -14,7 +30,7 @@ public class WhatAuthResponse {
         return attributes;
     }
 
-    public void setAttributes(Map<String, String> attributes) {
+    public void setAttributes(final Map<String, String> attributes) {
         this.attributes = attributes;
     }
 
@@ -22,7 +38,7 @@ public class WhatAuthResponse {
         return requiredFields;
     }
 
-    public void setRequiredFields(ArrayList<String> requiredFields) {
+    public void setRequiredFields(final ArrayList<String> requiredFields) {
         this.requiredFields = requiredFields;
     }
 
@@ -30,13 +46,13 @@ public class WhatAuthResponse {
         return requiredHeaders;
     }
 
-    public void setRequiredHeaders(Map<String, String> requiredHeaders) {
+    public void setRequiredHeaders(final Map<String, String> requiredHeaders) {
         this.requiredHeaders = requiredHeaders;
     }
 
     private Map<String, String> attributes;
     private ArrayList<String> requiredFields;
-    private Map<String,String> requiredHeaders;
+    private Map<String, String> requiredHeaders;
 
 
 }

--- a/gaffer-as-a-service/gaas-openshift-sidecar/src/test/java/uk/gov/gchq/gaffer/gaas/sidecar/controller/SidecarControllerTest.java
+++ b/gaffer-as-a-service/gaas-openshift-sidecar/src/test/java/uk/gov/gchq/gaffer/gaas/sidecar/controller/SidecarControllerTest.java
@@ -20,7 +20,14 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
 import org.springframework.test.web.reactive.server.WebTestClient;
+import uk.gov.gchq.gaffer.gaas.sidecar.models.WhatAuthResponse;
 import uk.gov.gchq.gaffer.gaas.sidecar.util.UnitTest;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @WebFluxTest(controllers = SidecarController.class)
 @UnitTest
@@ -37,5 +44,20 @@ public class SidecarControllerTest {
                 .exchange()
                 .expectStatus().is2xxSuccessful()
                 .expectBody().toString().equals(xemail);
+    }
+
+    @Test
+    void whatAuthShouldReturnWhatAuthInformationWhenSuccess() {
+        String expected = "{\"attributes\":{\"withCredentials\":\"true\"},\"requiredFields\":[],\"requiredHeaders\":{}}";
+        WebTestClient.BodyContentSpec response = webClient.get()
+                .uri("/what-auth")
+                .header("x-email", "mytest@email.com")
+                .exchange()
+                .expectStatus().is2xxSuccessful()
+                .expectBody().consumeWith(res -> {
+                    final String body = new String(res.getResponseBody(), UTF_8);
+
+                    assertEquals(expected, body);
+                });
     }
 }

--- a/gaffer-as-a-service/gaas-openshift-sidecar/src/test/java/uk/gov/gchq/gaffer/gaas/sidecar/controller/SidecarControllerTest.java
+++ b/gaffer-as-a-service/gaas-openshift-sidecar/src/test/java/uk/gov/gchq/gaffer/gaas/sidecar/controller/SidecarControllerTest.java
@@ -20,11 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
 import org.springframework.test.web.reactive.server.WebTestClient;
-import uk.gov.gchq.gaffer.gaas.sidecar.models.WhatAuthResponse;
 import uk.gov.gchq.gaffer.gaas.sidecar.util.UnitTest;
-
-import java.util.ArrayList;
-import java.util.HashMap;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;


### PR DESCRIPTION
Hi @t92549 @GCHQDeveloper314 

This PR links to ticket #306 

It provides an extra endpoint to the sidecars which enable the dynamic UI (which will be introduced in a separate PR) to function.

There is one model between the 2 which are identical - `WhatAuthResponse` - which could be moved into a common location such as rest/util or rest/model but I'm not sure if we want to introduce rest as a dependency on the sidecars so currently I have left `WhatAuthResponse` as a model in BOTH sidecars. Let me know if you want this to be moved into a shared location such as those I've mentioned. 
