### PR TITLE
Gh 310 reimplement tagging

### DIFF
--- a/gaffer-as-a-service/gaas-jwt-sidecar/src/main/java/uk/gov/gchq/gaffer/gaas/sidecar/controller/CustomFilter.java
+++ b/gaffer-as-a-service/gaas-jwt-sidecar/src/main/java/uk/gov/gchq/gaffer/gaas/sidecar/controller/CustomFilter.java
@@ -78,7 +78,9 @@ public class CustomFilter implements GlobalFilter {
             UserDetails userDetails = this.jwtUserDetailsService.loadUserByUsername(username);
 
             if (jwtTokenUtil.validateToken(jwtToken, userDetails)) {
-                return chain.filter(exchange).then(Mono.fromRunnable(() -> {
+                ServerHttpRequest mutatedRequest = exchange.getRequest().mutate().header("username", username).build();
+                ServerWebExchange mutatedExchange = exchange.mutate().request(mutatedRequest).build();
+                return chain.filter(mutatedExchange).then(Mono.fromRunnable(() -> {
                     ServerHttpResponse response = exchange.getResponse();
                     logger.info("Post Filter = " + response.getStatusCode());
                 }));

--- a/gaffer-as-a-service/gaas-jwt-sidecar/src/test/java/uk/gov/gchq/gaffer/gaas/sidecar/controller/CustomFilterTest.java
+++ b/gaffer-as-a-service/gaas-jwt-sidecar/src/test/java/uk/gov/gchq/gaffer/gaas/sidecar/controller/CustomFilterTest.java
@@ -34,6 +34,7 @@ import uk.gov.gchq.gaffer.gaas.sidecar.auth.JwtTokenUtil;
 import uk.gov.gchq.gaffer.gaas.sidecar.auth.JwtUserDetailsService;
 import uk.gov.gchq.gaffer.gaas.sidecar.util.UnitTest;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -96,7 +97,7 @@ public class CustomFilterTest {
         customFilter.filter(exchange, filterChain).block();
 
         exchange.getResponse().setComplete();
-
+        assertEquals("user" , exchange.getRequest().getHeaders().get("username").get(0));
         assertTrue(exchange.getResponse().getStatusCode().is2xxSuccessful());
     }
 

--- a/gaffer-as-a-service/gaas-jwt-sidecar/src/test/java/uk/gov/gchq/gaffer/gaas/sidecar/controller/CustomFilterTest.java
+++ b/gaffer-as-a-service/gaas-jwt-sidecar/src/test/java/uk/gov/gchq/gaffer/gaas/sidecar/controller/CustomFilterTest.java
@@ -97,7 +97,7 @@ public class CustomFilterTest {
         customFilter.filter(exchange, filterChain).block();
 
         exchange.getResponse().setComplete();
-        assertEquals("user" , exchange.getRequest().getHeaders().get("username").get(0));
+        assertEquals("user", exchange.getRequest().getHeaders().get("username").get(0));
         assertTrue(exchange.getResponse().getStatusCode().is2xxSuccessful());
     }
 

--- a/gaffer-as-a-service/gaas-openshift-sidecar/src/main/java/uk/gov/gchq/gaffer/gaas/sidecar/controller/CustomFilter.java
+++ b/gaffer-as-a-service/gaas-openshift-sidecar/src/main/java/uk/gov/gchq/gaffer/gaas/sidecar/controller/CustomFilter.java
@@ -38,7 +38,9 @@ public class CustomFilter implements GlobalFilter {
 
         ServerHttpRequest request = exchange.getRequest();
         if (request.getHeaders().getFirst("x-email") != null) {
-            return chain.filter(exchange).then(Mono.fromRunnable(() -> {
+            ServerHttpRequest mutatedRequest = exchange.getRequest().mutate().header("username", request.getHeaders().getFirst("x-email")).build();
+            ServerWebExchange mutatedExchange = exchange.mutate().request(mutatedRequest).build();
+            return chain.filter(mutatedExchange).then(Mono.fromRunnable(() -> {
                 ServerHttpResponse response = exchange.getResponse();
                 logger.info("Post Filter = " + response.getStatusCode());
             }));

--- a/gaffer-as-a-service/gaas-openshift-sidecar/src/test/java/uk/gov/gchq/gaffer/gaas/sidecar/controller/CustomFilterTest.java
+++ b/gaffer-as-a-service/gaas-openshift-sidecar/src/test/java/uk/gov/gchq/gaffer/gaas/sidecar/controller/CustomFilterTest.java
@@ -30,6 +30,7 @@ import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 import uk.gov.gchq.gaffer.gaas.sidecar.util.UnitTest;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -62,7 +63,7 @@ public class CustomFilterTest {
         customFilter.filter(exchange, filterChain).block();
 
         exchange.getResponse().setComplete();
-
+        assertEquals("myemail@email.com" , exchange.getRequest().getHeaders().get("username").get(0));
         assertTrue(exchange.getResponse().getStatusCode().is2xxSuccessful());
     }
 

--- a/gaffer-as-a-service/gaas-openshift-sidecar/src/test/java/uk/gov/gchq/gaffer/gaas/sidecar/controller/CustomFilterTest.java
+++ b/gaffer-as-a-service/gaas-openshift-sidecar/src/test/java/uk/gov/gchq/gaffer/gaas/sidecar/controller/CustomFilterTest.java
@@ -63,7 +63,7 @@ public class CustomFilterTest {
         customFilter.filter(exchange, filterChain).block();
 
         exchange.getResponse().setComplete();
-        assertEquals("myemail@email.com" , exchange.getRequest().getHeaders().get("username").get(0));
+        assertEquals("myemail@email.com", exchange.getRequest().getHeaders().get("username").get(0));
         assertTrue(exchange.getResponse().getStatusCode().is2xxSuccessful());
     }
 

--- a/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/controller/GraphController.java
+++ b/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/controller/GraphController.java
@@ -46,6 +46,7 @@ import javax.validation.Valid;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -74,6 +75,11 @@ public class GraphController {
 
     @PostMapping(path = "/graphs", consumes = "application/json", produces = "application/json")
     public ResponseEntity<?> createGraph(@Valid @RequestBody final GaaSCreateRequestBody requestBody, @RequestHeader final HttpHeaders headers) throws GaaSRestApiException {
+        try {
+            addCreatorLabel(Objects.requireNonNull(headers.getFirst("username")));
+        } catch (Exception e) {
+            //Add logging to register error
+        }
         if (requestBody.isFederatedStoreRequest()) {
             createFederatedStoreGraphService.createFederatedStore(requestBody);
         } else {
@@ -113,25 +119,14 @@ public class GraphController {
     }
 
 
-
-    @GetMapping(path = "/whoami", produces = "application/json")
-    ResponseEntity<String> whoami(@RequestHeader("x-email") final String email) {
-        if (addCreatorLabel(email)) {
-            return new ResponseEntity<String>(email, HttpStatus.OK);
-        }
-        return new ResponseEntity<>("Validation error: Email must consist of alphanumeric characters or '-', '_' and '.' ", HttpStatus.BAD_REQUEST);
-    }
-
-    private boolean addCreatorLabel(final String email) {
+    private void addCreatorLabel(final String email) {
         String strippedEmail = email;
         if (email.contains("@")) {
             strippedEmail = email.substring(0, email.indexOf('@'));
         }
         if (isCreatorLabelValid(strippedEmail)) {
             helmValuesOverridesHandler.addOverride("labels.creator", strippedEmail);
-            return true;
         }
-        return false;
     }
 
     private boolean isCreatorLabelValid(final String email) {

--- a/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/controller/GraphController.java
+++ b/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/controller/GraphController.java
@@ -17,6 +17,8 @@
 package uk.gov.gchq.gaffer.gaas.controller;
 
 import io.kubernetes.client.openapi.ApiClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -71,6 +73,7 @@ public class GraphController {
     private GetGaaSGraphConfigsService getStoreTypesService;
     @Autowired
     private HelmValuesOverridesHandler helmValuesOverridesHandler;
+    Logger logger = LoggerFactory.getLogger(GraphController.class);
 
 
     @PostMapping(path = "/graphs", consumes = "application/json", produces = "application/json")
@@ -78,7 +81,7 @@ public class GraphController {
         try {
             addCreatorLabel(Objects.requireNonNull(headers.getFirst("username")));
         } catch (Exception e) {
-            //Add logging to register error
+            logger.error("Could not retrieve username");
         }
         if (requestBody.isFederatedStoreRequest()) {
             createFederatedStoreGraphService.createFederatedStore(requestBody);

--- a/gaffer-as-a-service/gaas-rest/src/main/resources/application.properties
+++ b/gaffer-as-a-service/gaas-rest/src/main/resources/application.properties
@@ -22,5 +22,5 @@ worker.imagePullPolicy=IfNotPresent
 worker.helm.repo=https://gchq.github.io/gaffer-docker
 worker.restart.policy=Never
 worker.service.account=gaffer-workers
-chart.version=0.17.0
+chart.version=0.17.1
 spring.application.name=gaas-rest-service

--- a/gaffer-as-a-service/gaas-rest/src/test/java/uk/gov/gchq/gaffer/gaas/controller/GraphControllerTest.java
+++ b/gaffer-as-a-service/gaas-rest/src/test/java/uk/gov/gchq/gaffer/gaas/controller/GraphControllerTest.java
@@ -23,6 +23,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MvcResult;
 import uk.gov.gchq.gaffer.gaas.AbstractTest;
 import uk.gov.gchq.gaffer.gaas.exception.GaaSRestApiException;
+import uk.gov.gchq.gaffer.gaas.handlers.HelmValuesOverridesHandler;
 import uk.gov.gchq.gaffer.gaas.model.GaaSCreateRequestBody;
 import uk.gov.gchq.gaffer.gaas.model.GaaSGraph;
 import uk.gov.gchq.gaffer.gaas.model.GafferConfigSpec;
@@ -34,11 +35,13 @@ import uk.gov.gchq.gaffer.gaas.services.DeleteGraphService;
 import uk.gov.gchq.gaffer.gaas.services.GetGaaSGraphConfigsService;
 import uk.gov.gchq.gaffer.gaas.services.GetGaffersService;
 import uk.gov.gchq.gaffer.gaas.services.GetNamespacesService;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
@@ -66,12 +69,14 @@ class GraphControllerTest extends AbstractTest {
     private GetNamespacesService getNamespacesService;
     @MockBean
     private GetGaaSGraphConfigsService getStoreTypesService;
+    @MockBean
+    private HelmValuesOverridesHandler helmValuesOverridesHandler;
 
     @Test
     void getStoretypes_ReturnsStoretypesAsList_whenSuccessful() throws Exception {
         final List<GafferConfigSpec> specs = Arrays.asList(
-                new GafferConfigSpec("accumulo", new String[] {"schema"}),
-                new GafferConfigSpec("federated", new String[] {"proxies"}));
+                new GafferConfigSpec("accumulo", new String[]{"schema"}),
+                new GafferConfigSpec("federated", new String[]{"proxies"}));
         when(getStoreTypesService.getGafferConfigSpecs()).thenReturn(specs);
 
         final MvcResult getStoretypeResponse = mvc.perform(get("/storetypes")
@@ -115,6 +120,7 @@ class GraphControllerTest extends AbstractTest {
         final MvcResult result = mvc.perform(post("/graphs")
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header("Authorization", token)
+                .header("username", "someUser")
                 .content(inputJson)).andReturn();
 
         verify(createGraphService, times(1)).createGraph(any(GaaSCreateRequestBody.class));
@@ -240,6 +246,7 @@ class GraphControllerTest extends AbstractTest {
         final MvcResult result = mvc.perform(post("/graphs")
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header("Authorization", token)
+                .header("username", "someUser")
                 .content(inputJson)).andReturn();
 
         verify(createGraphService, times(1)).createGraph(any(GaaSCreateRequestBody.class));
@@ -296,6 +303,7 @@ class GraphControllerTest extends AbstractTest {
         final MvcResult result = mvc.perform(post("/graphs")
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header("Authorization", token)
+                .header("username", "someUser")
                 .content(inputJson)).andReturn();
 
         verify(createGraphService, times(1)).createGraph(any(GaaSCreateRequestBody.class));
@@ -311,6 +319,7 @@ class GraphControllerTest extends AbstractTest {
         final MvcResult result = mvc.perform(post("/graphs")
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header("Authorization", token)
+                .header("username", "someUser")
                 .content(inputJson)).andReturn();
 
         verify(createGraphService, times(1)).createGraph(any(GaaSCreateRequestBody.class));
@@ -358,6 +367,7 @@ class GraphControllerTest extends AbstractTest {
         final MvcResult result = mvc.perform(post("/graphs")
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header("Authorization", token)
+                .header("username", "someUser")
                 .content(inputJson)).andReturn();
 
         assertEquals(500, result.getResponse().getStatus());
@@ -388,6 +398,7 @@ class GraphControllerTest extends AbstractTest {
         final MvcResult result = mvc.perform(post("/graphs")
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header("Authorization", token)
+                .header("username", "someUser")
                 .content(mapToJson(request)))
                 .andReturn();
 
@@ -404,6 +415,7 @@ class GraphControllerTest extends AbstractTest {
         final MvcResult result = mvc.perform(post("/graphs")
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header("Authorization", token)
+                .header("username", "someUser")
                 .content(mapToJson(request)))
                 .andReturn();
 
@@ -425,51 +437,13 @@ class GraphControllerTest extends AbstractTest {
         final MvcResult result = mvc.perform(post("/graphs")
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header("Authorization", token)
+                .header("username", "someUser")
                 .content(request))
                 .andReturn();
 
         assertEquals(201, result.getResponse().getStatus());
         verify(createFederatedStoreGraphService, times(1)).createFederatedStore(any(GaaSCreateRequestBody.class));
     }
-
-    @Test
-    void whoamiShouldReturnUserEmailWhenSuccessful() throws Exception {
-
-        final MvcResult result = mvc.perform(get("/whoami")
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header("Authorization", token)
-                .header("x-email", "test@gmail.com")
-        )
-                .andReturn();
-
-        assertEquals(200, result.getResponse().getStatus());
-        assertEquals("test@gmail.com", result.getResponse().getContentAsString());
-    }
-
-    @Test
-    void whoamiShouldReturnUser400WhenHeaderEmailIsNull() throws Exception {
-
-        final MvcResult result = mvc.perform(get("/whoami")
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header("Authorization", token))
-                .andReturn();
-
-        assertEquals(400, result.getResponse().getStatus());
-    }
-
-    @Test
-    void whoamiShouldReturnUser400WhenHeaderEmailContainsSymbols() throws Exception {
-
-        final MvcResult result = mvc.perform(get("/whoami")
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header("Authorization", token)
-                .header("x-email", "test!@@gmail.com")
-        )
-                .andReturn();
-
-        assertEquals(400, result.getResponse().getStatus());
-    }
-
 
     private LinkedHashMap<String, Object> getSchema() {
         final LinkedHashMap<String, Object> elementsSchema = new LinkedHashMap<>();


### PR DESCRIPTION
Hi @t92549 @GCHQDeveloper314 

PR to reimplement tagging functionality which was broken when sidecar authentication was implemented.

Solved by adding a "username" header to the requests coming through the sidecar filter

#310 