### PR TITLE
Gh 325 graph sharing

### DIFF
--- a/gaffer-as-a-service/gaas-rest/pom.xml
+++ b/gaffer-as-a-service/gaas-rest/pom.xml
@@ -151,6 +151,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <version>0.2.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.kubernetes</groupId>
             <artifactId>client-java-extended</artifactId>
             <version>${kubernetes.version}</version>

--- a/gaffer-as-a-service/gaas-rest/pom.xml
+++ b/gaffer-as-a-service/gaas-rest/pom.xml
@@ -225,12 +225,12 @@
         <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client</artifactId>
-            <version>5.12.1</version>
+            <version>5.12.2</version>
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-server-mock</artifactId>
-            <version>5.12.1</version>
+            <version>5.12.2</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>

--- a/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/client/GafferClient.java
+++ b/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/client/GafferClient.java
@@ -65,7 +65,7 @@ public class GafferClient {
     public boolean addCollaborator(final GaaSAddCollaboratorRequestBody requestBody) throws GaaSRestApiException {
         KubernetesClient kubernetesClient = new DefaultKubernetesClient();
         try {
-            return deploymentHandler.addGraphCollaborator(requestBody.getGraphId(), kubernetesClient, emailStripper(requestBody.getCollaborator()));
+            return deploymentHandler.addGraphCollaborator(requestBody.getGraphId(), kubernetesClient, emailStripper(requestBody.getUsername()));
         } catch (ApiException e) {
             LOGGER.error("Failed to add collaborator label");
             throw from(e);
@@ -75,7 +75,7 @@ public class GafferClient {
     public boolean addCollaboratorWithUsername(final GaaSAddCollaboratorRequestBody requestBody, final String username) throws GaaSRestApiException {
         KubernetesClient kubernetesClient = new DefaultKubernetesClient();
         try {
-            return deploymentHandler.addGraphCollaboratorWithUsername(requestBody.getGraphId(), kubernetesClient, emailStripper(requestBody.getCollaborator()), username);
+            return deploymentHandler.addGraphCollaboratorWithUsername(requestBody.getGraphId(), kubernetesClient, emailStripper(requestBody.getUsername()), username);
         } catch (ApiException e) {
             LOGGER.error("Failed to add collaborator label");
             throw from(e);

--- a/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/client/GafferClient.java
+++ b/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/client/GafferClient.java
@@ -72,6 +72,16 @@ public class GafferClient {
         return false;
     }
 
+    public boolean addCollaboratorWithUsername(final GaaSAddCollaboratorRequestBody requestBody, final String username) {
+        KubernetesClient kubernetesClient = new DefaultKubernetesClient();
+        try {
+            return deploymentHandler.addGraphCollaboratorWithUsername(requestBody.getGraphId(), kubernetesClient, requestBody.getCollaborator(), username);
+        } catch (ApiException e) {
+            //
+        }
+        return false;
+    }
+
     public List<GaaSGraph> listAllGaffers() throws GaaSRestApiException {
         KubernetesClient kubernetesClient = new DefaultKubernetesClient();
         try {

--- a/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/client/GafferClient.java
+++ b/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/client/GafferClient.java
@@ -72,14 +72,14 @@ public class GafferClient {
         return false;
     }
 
-    public boolean addCollaboratorWithUsername(final GaaSAddCollaboratorRequestBody requestBody, final String username) {
+    public boolean addCollaboratorWithUsername(final GaaSAddCollaboratorRequestBody requestBody, final String username) throws GaaSRestApiException {
         KubernetesClient kubernetesClient = new DefaultKubernetesClient();
         try {
             return deploymentHandler.addGraphCollaboratorWithUsername(requestBody.getGraphId(), kubernetesClient, requestBody.getCollaborator(), username);
         } catch (ApiException e) {
-            //
+            LOGGER.error("Failed to add collaborator label");
+            throw from(e);
         }
-        return false;
     }
 
     public List<GaaSGraph> listAllGaffers() throws GaaSRestApiException {

--- a/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/client/GafferClient.java
+++ b/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/client/GafferClient.java
@@ -62,14 +62,14 @@ public class GafferClient {
         }
     }
 
-    public boolean addCollaborator(final GaaSAddCollaboratorRequestBody requestBody) {
+    public boolean addCollaborator(final GaaSAddCollaboratorRequestBody requestBody) throws GaaSRestApiException {
         KubernetesClient kubernetesClient = new DefaultKubernetesClient();
         try {
             return deploymentHandler.addGraphCollaborator(requestBody.getGraphId(), kubernetesClient, requestBody.getCollaborator());
         } catch (ApiException e) {
-            //
+            LOGGER.error("Failed to add collaborator label");
+            throw from(e);
         }
-        return false;
     }
 
     public boolean addCollaboratorWithUsername(final GaaSAddCollaboratorRequestBody requestBody, final String username) throws GaaSRestApiException {

--- a/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/client/GafferClient.java
+++ b/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/client/GafferClient.java
@@ -65,7 +65,7 @@ public class GafferClient {
     public boolean addCollaborator(final GaaSAddCollaboratorRequestBody requestBody) throws GaaSRestApiException {
         KubernetesClient kubernetesClient = new DefaultKubernetesClient();
         try {
-            return deploymentHandler.addGraphCollaborator(requestBody.getGraphId(), kubernetesClient, requestBody.getCollaborator());
+            return deploymentHandler.addGraphCollaborator(requestBody.getGraphId(), kubernetesClient, emailStripper(requestBody.getCollaborator()));
         } catch (ApiException e) {
             LOGGER.error("Failed to add collaborator label");
             throw from(e);
@@ -75,7 +75,7 @@ public class GafferClient {
     public boolean addCollaboratorWithUsername(final GaaSAddCollaboratorRequestBody requestBody, final String username) throws GaaSRestApiException {
         KubernetesClient kubernetesClient = new DefaultKubernetesClient();
         try {
-            return deploymentHandler.addGraphCollaboratorWithUsername(requestBody.getGraphId(), kubernetesClient, requestBody.getCollaborator(), username);
+            return deploymentHandler.addGraphCollaboratorWithUsername(requestBody.getGraphId(), kubernetesClient, emailStripper(requestBody.getCollaborator()), username);
         } catch (ApiException e) {
             LOGGER.error("Failed to add collaborator label");
             throw from(e);
@@ -138,6 +138,14 @@ public class GafferClient {
         return v1NamespaceList.getItems().stream()
                 .map(v1Namespace -> v1Namespace.getMetadata().getName())
                 .collect(Collectors.toList());
+    }
+
+    private String emailStripper(final String email) {
+        String strippedEmail = email;
+        if (email.contains("@")) {
+            strippedEmail = email.substring(0, email.indexOf('@')) + "-AT-" + email.substring(email.indexOf('@') + 1);
+        }
+        return strippedEmail;
     }
 
 }

--- a/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/client/GafferClient.java
+++ b/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/client/GafferClient.java
@@ -27,6 +27,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 import uk.gov.gchq.gaffer.gaas.exception.GaaSRestApiException;
 import uk.gov.gchq.gaffer.gaas.handlers.DeploymentHandler;
+import uk.gov.gchq.gaffer.gaas.model.GaaSAddCollaboratorRequestBody;
 import uk.gov.gchq.gaffer.gaas.model.GaaSGraph;
 import uk.gov.gchq.gaffer.gaas.model.GraphUrl;
 import uk.gov.gchq.gaffer.gaas.model.v1.Gaffer;
@@ -55,10 +56,20 @@ public class GafferClient {
             if (requestBody == null || requestBody.getMetadata() == null) {
                 LOGGER.error("Failed to create Gaffer \"\". Error: ", e);
             } else {
-                LOGGER.error("Failed to create Gaffer with name {}. Error: ",  requestBody.getMetadata().getName(), e);
+                LOGGER.error("Failed to create Gaffer with name {}. Error: ", requestBody.getMetadata().getName(), e);
             }
             throw from(e);
         }
+    }
+
+    public boolean addCollaborator(final GaaSAddCollaboratorRequestBody requestBody) {
+        KubernetesClient kubernetesClient = new DefaultKubernetesClient();
+        try {
+            return deploymentHandler.addGraphCollaborator(requestBody.getGraphId(), kubernetesClient, requestBody.getCollaborator());
+        } catch (ApiException e) {
+            //
+        }
+        return false;
     }
 
     public List<GaaSGraph> listAllGaffers() throws GaaSRestApiException {

--- a/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/controller/GraphController.java
+++ b/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/controller/GraphController.java
@@ -125,7 +125,6 @@ public class GraphController {
                 return new ResponseEntity<>(HttpStatus.ACCEPTED);
             }
         }
-
         return new ResponseEntity<>(HttpStatus.NOT_FOUND);
     }
 

--- a/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/controller/GraphController.java
+++ b/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/controller/GraphController.java
@@ -116,12 +116,12 @@ public class GraphController {
 
     @PostMapping(path = "/addCollaborator", produces = "application/json")
     public ResponseEntity<?> addCollaborator(@RequestBody final GaaSAddCollaboratorRequestBody requestBody, @RequestHeader final HttpHeaders headers) {
-        if(isAdmin(headers.getFirst("username"))){
+        if (isAdmin(headers.getFirst("username"))) {
             if (updateGraphCollaboratorsService.updateCollaborators(requestBody)) {
                 return new ResponseEntity<>(HttpStatus.ACCEPTED);
             }
-        }else{
-            if(updateGraphCollaboratorsService.updateCollaboratorsWithUsername(requestBody, emailStripper(headers.getFirst("username")))){
+        } else {
+            if (updateGraphCollaboratorsService.updateCollaboratorsWithUsername(requestBody, emailStripper(headers.getFirst("username")))) {
                 return new ResponseEntity<>(HttpStatus.ACCEPTED);
             }
         }

--- a/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/controller/GraphController.java
+++ b/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/controller/GraphController.java
@@ -115,7 +115,7 @@ public class GraphController {
     }
 
     @PostMapping(path = "/addCollaborator", produces = "application/json")
-    public ResponseEntity<?> addCollaborator(@RequestBody final GaaSAddCollaboratorRequestBody requestBody, @RequestHeader final HttpHeaders headers) {
+    public ResponseEntity<?> addCollaborator(@RequestBody final GaaSAddCollaboratorRequestBody requestBody, @RequestHeader final HttpHeaders headers) throws GaaSRestApiException {
         if (isAdmin(headers.getFirst("username"))) {
             if (updateGraphCollaboratorsService.updateCollaborators(requestBody)) {
                 return new ResponseEntity<>(HttpStatus.ACCEPTED);

--- a/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/controller/GraphController.java
+++ b/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/controller/GraphController.java
@@ -35,6 +35,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.gchq.gaffer.gaas.exception.GaaSRestApiException;
 import uk.gov.gchq.gaffer.gaas.handlers.HelmValuesOverridesHandler;
+import uk.gov.gchq.gaffer.gaas.model.GaaSAddCollaboratorRequestBody;
 import uk.gov.gchq.gaffer.gaas.model.GaaSCreateRequestBody;
 import uk.gov.gchq.gaffer.gaas.model.GaaSGraph;
 import uk.gov.gchq.gaffer.gaas.model.GafferConfigSpec;
@@ -44,6 +45,7 @@ import uk.gov.gchq.gaffer.gaas.services.DeleteGraphService;
 import uk.gov.gchq.gaffer.gaas.services.GetGaaSGraphConfigsService;
 import uk.gov.gchq.gaffer.gaas.services.GetGaffersService;
 import uk.gov.gchq.gaffer.gaas.services.GetNamespacesService;
+import uk.gov.gchq.gaffer.gaas.services.UpdateGraphCollaboratorsService;
 
 import javax.validation.Valid;
 import java.util.ArrayList;
@@ -78,6 +80,8 @@ public class GraphController {
     private GetGaaSGraphConfigsService getStoreTypesService;
     @Autowired
     private HelmValuesOverridesHandler helmValuesOverridesHandler;
+    @Autowired
+    private UpdateGraphCollaboratorsService updateGraphCollaboratorsService;
     @Value("${admin.users: {}}")
     private String[] admins;
 
@@ -108,6 +112,14 @@ public class GraphController {
             responseBody.put("graphs", getGaffersService.getUserCreatedGraphs(emailStripper(headers.getFirst("username"))));
         }
         return new ResponseEntity(responseBody, HttpStatus.OK);
+    }
+
+    @PostMapping(path="/addCollaborator", produces = "application/json")
+    public ResponseEntity<?> addCollaborator(@RequestBody final GaaSAddCollaboratorRequestBody requestBody, @RequestHeader final HttpHeaders headers){
+        if(updateGraphCollaboratorsService.updateCollaborators(requestBody)){
+            return new ResponseEntity<>(HttpStatus.ACCEPTED);
+        };
+        return new ResponseEntity<>(HttpStatus.NOT_FOUND);
     }
 
     @GetMapping(path = "/storetypes", produces = "application/json")

--- a/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/controller/GraphController.java
+++ b/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/controller/GraphController.java
@@ -114,11 +114,11 @@ public class GraphController {
         return new ResponseEntity(responseBody, HttpStatus.OK);
     }
 
-    @PostMapping(path="/addCollaborator", produces = "application/json")
-    public ResponseEntity<?> addCollaborator(@RequestBody final GaaSAddCollaboratorRequestBody requestBody, @RequestHeader final HttpHeaders headers){
-        if(updateGraphCollaboratorsService.updateCollaborators(requestBody)){
+    @PostMapping(path = "/addCollaborator", produces = "application/json")
+    public ResponseEntity<?> addCollaborator(@RequestBody final GaaSAddCollaboratorRequestBody requestBody, @RequestHeader final HttpHeaders headers) {
+        if (updateGraphCollaboratorsService.updateCollaborators(requestBody)) {
             return new ResponseEntity<>(HttpStatus.ACCEPTED);
-        };
+        }
         return new ResponseEntity<>(HttpStatus.NOT_FOUND);
     }
 

--- a/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/controller/GraphController.java
+++ b/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/controller/GraphController.java
@@ -173,7 +173,7 @@ public class GraphController {
     private String emailStripper(final String email) {
         String strippedEmail = email;
         if (email.contains("@")) {
-            strippedEmail = email.substring(0, email.indexOf('@'));
+            strippedEmail = email.substring(0, email.indexOf('@')) + "-AT-" + email.substring(email.indexOf('@') + 1);
         }
         return strippedEmail;
     }

--- a/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/controller/GraphController.java
+++ b/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/controller/GraphController.java
@@ -116,9 +116,16 @@ public class GraphController {
 
     @PostMapping(path = "/addCollaborator", produces = "application/json")
     public ResponseEntity<?> addCollaborator(@RequestBody final GaaSAddCollaboratorRequestBody requestBody, @RequestHeader final HttpHeaders headers) {
-        if (updateGraphCollaboratorsService.updateCollaborators(requestBody)) {
-            return new ResponseEntity<>(HttpStatus.ACCEPTED);
+        if(isAdmin(headers.getFirst("username"))){
+            if (updateGraphCollaboratorsService.updateCollaborators(requestBody)) {
+                return new ResponseEntity<>(HttpStatus.ACCEPTED);
+            }
+        }else{
+            if(updateGraphCollaboratorsService.updateCollaboratorsWithUsername(requestBody, emailStripper(headers.getFirst("username")))){
+                return new ResponseEntity<>(HttpStatus.ACCEPTED);
+            }
         }
+
         return new ResponseEntity<>(HttpStatus.NOT_FOUND);
     }
 

--- a/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/handlers/DeploymentHandler.java
+++ b/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/handlers/DeploymentHandler.java
@@ -104,10 +104,23 @@ public class DeploymentHandler {
 
     public boolean addGraphCollaborator(final String gaffer, final KubernetesClient kubernetesClient, final String usernameToAdd) throws ApiException {
         try {
-            // Scales Deployment to 2 replicas
             updateDeploymentLabels(gaffer + "-gaffer-api", kubernetesClient, usernameToAdd);
             updateDeploymentLabels(gaffer + "-gaffer-ui", kubernetesClient, usernameToAdd);
             return true;
+        } catch (KubernetesClientException e) {
+            LOGGER.error("Failed to add collaborator.", e);
+            throw new ApiException(e.getCode(), e.getMessage());
+        }
+    }
+
+    public boolean addGraphCollaboratorWithUsername(final String gaffer, final KubernetesClient kubernetesClient, final String usernameToAdd, final String username) throws ApiException {
+        try {
+            if(kubernetesClient.apps().deployments().inNamespace(NAMESPACE).withName(gaffer+"-gaffer-api").get().getMetadata().getLabels().get("creator").equals(username)){
+                updateDeploymentLabels(gaffer + "-gaffer-api", kubernetesClient, usernameToAdd);
+                updateDeploymentLabels(gaffer + "-gaffer-ui", kubernetesClient, usernameToAdd);
+                return true;
+            }
+            return false;
         } catch (KubernetesClientException e) {
             LOGGER.error("Failed to add collaborator.", e);
             throw new ApiException(e.getCode(), e.getMessage());

--- a/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/handlers/DeploymentHandler.java
+++ b/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/handlers/DeploymentHandler.java
@@ -17,7 +17,6 @@
 package uk.gov.gchq.gaffer.gaas.handlers;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
-import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
@@ -44,9 +43,7 @@ import uk.gov.gchq.gaffer.gaas.model.v1.RestApiStatus;
 import javax.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import static uk.gov.gchq.gaffer.gaas.util.Constants.GAFFER_NAMESPACE_LABEL;
 import static uk.gov.gchq.gaffer.gaas.util.Constants.GAFFER_NAME_LABEL;

--- a/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/handlers/DeploymentHandler.java
+++ b/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/handlers/DeploymentHandler.java
@@ -29,7 +29,6 @@ import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1Secret;
 import io.kubernetes.client.openapi.models.V1Status;
-import org.jetbrains.annotations.NotNull;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.slf4j.LoggerFactory;
@@ -42,6 +41,7 @@ import uk.gov.gchq.gaffer.gaas.model.GaaSGraph;
 import uk.gov.gchq.gaffer.gaas.model.v1.Gaffer;
 import uk.gov.gchq.gaffer.gaas.model.v1.RestApiStatus;
 
+import javax.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -108,8 +108,8 @@ public class DeploymentHandler {
     public boolean addGraphCollaborator(final String gaffer, final KubernetesClient kubernetesClient, final String usernameToAdd) throws ApiException {
         try {
             // Scales Deployment to 2 replicas
-            updateDeploymentLabels(gaffer+"-gaffer-api", kubernetesClient, usernameToAdd);
-            updateDeploymentLabels(gaffer+"-gaffer-ui", kubernetesClient, usernameToAdd);
+            updateDeploymentLabels(gaffer + "-gaffer-api", kubernetesClient, usernameToAdd);
+            updateDeploymentLabels(gaffer + "-gaffer-ui", kubernetesClient, usernameToAdd);
             return true;
         } catch (KubernetesClientException e) {
             LOGGER.error("Failed to add collaborator.", e);

--- a/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/handlers/DeploymentHandler.java
+++ b/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/handlers/DeploymentHandler.java
@@ -115,7 +115,7 @@ public class DeploymentHandler {
 
     public boolean addGraphCollaboratorWithUsername(final String gaffer, final KubernetesClient kubernetesClient, final String usernameToAdd, final String username) throws ApiException {
         try {
-            if(kubernetesClient.apps().deployments().inNamespace(NAMESPACE).withName(gaffer+"-gaffer-api").get().getMetadata().getLabels().get("creator").equals(username)){
+            if (kubernetesClient.apps().deployments().inNamespace(NAMESPACE).withName(gaffer + "-gaffer-api").get().getMetadata().getLabels().get("creator").equals(username)) {
                 updateDeploymentLabels(gaffer + "-gaffer-api", kubernetesClient, usernameToAdd);
                 updateDeploymentLabels(gaffer + "-gaffer-ui", kubernetesClient, usernameToAdd);
                 return true;

--- a/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/handlers/DeploymentHandler.java
+++ b/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/handlers/DeploymentHandler.java
@@ -252,6 +252,7 @@ public class DeploymentHandler {
     public List<GaaSGraph> getDeploymentsByUsername(final KubernetesClient kubernetesClient, final String username) throws ApiException {
         try {
             List<Deployment> deploymentList = kubernetesClient.apps().deployments().inNamespace(NAMESPACE).withLabel("creator", username).list().getItems();
+            deploymentList.addAll(kubernetesClient.apps().deployments().inNamespace(NAMESPACE).withLabel("collaborator/" + username, username).list().getItems());
             return listAllGraphs(kubernetesClient, getAPIDeployments(deploymentList));
         } catch (Exception e) {
             LOGGER.debug("Failed to list all Gaffers.");

--- a/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/model/GaaSAddCollaboratorRequestBody.java
+++ b/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/model/GaaSAddCollaboratorRequestBody.java
@@ -21,22 +21,22 @@ public class GaaSAddCollaboratorRequestBody {
     @JsonProperty
     private String graphId;
     @JsonProperty
-    private String collaborator;
+    private String username;
 
     public GaaSAddCollaboratorRequestBody() {
 
     }
 
-    public GaaSAddCollaboratorRequestBody(final String graphId, final String collaborator) {
+    public GaaSAddCollaboratorRequestBody(final String graphId, final String username) {
         this.graphId = graphId;
-        this.collaborator = collaborator;
+        this.username = username;
     }
 
     public String getGraphId() {
         return graphId;
     }
 
-    public String getCollaborator() {
-        return collaborator;
+    public String getUsername() {
+        return username;
     }
 }

--- a/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/model/GaaSAddCollaboratorRequestBody.java
+++ b/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/model/GaaSAddCollaboratorRequestBody.java
@@ -1,0 +1,27 @@
+package uk.gov.gchq.gaffer.gaas.model;
+
+import org.codehaus.jackson.annotate.JsonProperty;
+
+public class GaaSAddCollaboratorRequestBody {
+    @JsonProperty
+    private String graphId;
+    @JsonProperty
+    private String collaborator;
+
+    public GaaSAddCollaboratorRequestBody() {
+
+    }
+
+    public GaaSAddCollaboratorRequestBody(final String graphId, final String collaborator) {
+        this.graphId = graphId;
+        this.collaborator = collaborator;
+    }
+
+    public String getGraphId() {
+        return graphId;
+    }
+
+    public String getCollaborator() {
+        return collaborator;
+    }
+}

--- a/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/model/GaaSAddCollaboratorRequestBody.java
+++ b/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/model/GaaSAddCollaboratorRequestBody.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package uk.gov.gchq.gaffer.gaas.model;
 
 import org.codehaus.jackson.annotate.JsonProperty;

--- a/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/services/UpdateGraphCollaboratorsService.java
+++ b/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/services/UpdateGraphCollaboratorsService.java
@@ -1,0 +1,16 @@
+package uk.gov.gchq.gaffer.gaas.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.gov.gchq.gaffer.gaas.client.GafferClient;
+import uk.gov.gchq.gaffer.gaas.model.GaaSAddCollaboratorRequestBody;
+
+@Service
+public class UpdateGraphCollaboratorsService {
+    @Autowired
+    private GafferClient gafferClient;
+
+    public boolean updateCollaborators(final GaaSAddCollaboratorRequestBody requestBody){
+        return gafferClient.addCollaborator(requestBody);
+    }
+}

--- a/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/services/UpdateGraphCollaboratorsService.java
+++ b/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/services/UpdateGraphCollaboratorsService.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package uk.gov.gchq.gaffer.gaas.services;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,7 +25,7 @@ public class UpdateGraphCollaboratorsService {
     @Autowired
     private GafferClient gafferClient;
 
-    public boolean updateCollaborators(final GaaSAddCollaboratorRequestBody requestBody){
+    public boolean updateCollaborators(final GaaSAddCollaboratorRequestBody requestBody) {
         return gafferClient.addCollaborator(requestBody);
     }
 }

--- a/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/services/UpdateGraphCollaboratorsService.java
+++ b/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/services/UpdateGraphCollaboratorsService.java
@@ -18,6 +18,7 @@ package uk.gov.gchq.gaffer.gaas.services;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.gchq.gaffer.gaas.client.GafferClient;
+import uk.gov.gchq.gaffer.gaas.exception.GaaSRestApiException;
 import uk.gov.gchq.gaffer.gaas.model.GaaSAddCollaboratorRequestBody;
 
 @Service
@@ -28,7 +29,7 @@ public class UpdateGraphCollaboratorsService {
     public boolean updateCollaborators(final GaaSAddCollaboratorRequestBody requestBody) {
         return gafferClient.addCollaborator(requestBody);
     }
-    public boolean updateCollaboratorsWithUsername(final GaaSAddCollaboratorRequestBody requestBody, final String username) {
+    public boolean updateCollaboratorsWithUsername(final GaaSAddCollaboratorRequestBody requestBody, final String username) throws GaaSRestApiException {
         return gafferClient.addCollaboratorWithUsername(requestBody, username);
     }
 }

--- a/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/services/UpdateGraphCollaboratorsService.java
+++ b/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/services/UpdateGraphCollaboratorsService.java
@@ -26,7 +26,7 @@ public class UpdateGraphCollaboratorsService {
     @Autowired
     private GafferClient gafferClient;
 
-    public boolean updateCollaborators(final GaaSAddCollaboratorRequestBody requestBody) {
+    public boolean updateCollaborators(final GaaSAddCollaboratorRequestBody requestBody) throws GaaSRestApiException {
         return gafferClient.addCollaborator(requestBody);
     }
     public boolean updateCollaboratorsWithUsername(final GaaSAddCollaboratorRequestBody requestBody, final String username) throws GaaSRestApiException {

--- a/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/services/UpdateGraphCollaboratorsService.java
+++ b/gaffer-as-a-service/gaas-rest/src/main/java/uk/gov/gchq/gaffer/gaas/services/UpdateGraphCollaboratorsService.java
@@ -28,4 +28,7 @@ public class UpdateGraphCollaboratorsService {
     public boolean updateCollaborators(final GaaSAddCollaboratorRequestBody requestBody) {
         return gafferClient.addCollaborator(requestBody);
     }
+    public boolean updateCollaboratorsWithUsername(final GaaSAddCollaboratorRequestBody requestBody, final String username) {
+        return gafferClient.addCollaboratorWithUsername(requestBody, username);
+    }
 }

--- a/gaffer-as-a-service/gaas-rest/src/test/java/uk/gov/gchq/gaffer/gaas/AbstractTest.java
+++ b/gaffer-as-a-service/gaas-rest/src/test/java/uk/gov/gchq/gaffer/gaas/AbstractTest.java
@@ -17,6 +17,7 @@
 package uk.gov.gchq.gaffer.gaas;
 
 import com.google.gson.Gson;
+import io.fabric8.mockwebserver.DefaultMockServer;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/gaffer-as-a-service/gaas-rest/src/test/java/uk/gov/gchq/gaffer/gaas/AbstractTest.java
+++ b/gaffer-as-a-service/gaas-rest/src/test/java/uk/gov/gchq/gaffer/gaas/AbstractTest.java
@@ -17,7 +17,6 @@
 package uk.gov.gchq.gaffer.gaas;
 
 import com.google.gson.Gson;
-import io.fabric8.mockwebserver.DefaultMockServer;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,6 +27,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.web.context.WebApplicationContext;
 import uk.gov.gchq.gaffer.gaas.client.GafferClient;
+
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
 

--- a/gaffer-as-a-service/gaas-rest/src/test/java/uk/gov/gchq/gaffer/gaas/client/GafferClientTest.java
+++ b/gaffer-as-a-service/gaas-rest/src/test/java/uk/gov/gchq/gaffer/gaas/client/GafferClientTest.java
@@ -126,6 +126,7 @@ class GafferClientTest {
 
         assertEquals(graphs, gaaSGraphs);
     }
+
     @Test
     void getGraphsWithUsername_ShouldReturnEmptyWhenNoGraphsExists() throws GaaSRestApiException {
 
@@ -176,6 +177,7 @@ class GafferClientTest {
         when(deploymentHandler.addGraphCollaborator(any(), any(), any())).thenReturn(true);
         assertTrue(gafferClient.addCollaborator(gaaSAddCollaboratorRequestBody));
     }
+
     @Test
     void addCollaboratorWithUsername_shouldReturnTrueWhenSuccess() throws ApiException, GaaSRestApiException {
         GaaSAddCollaboratorRequestBody gaaSAddCollaboratorRequestBody = new GaaSAddCollaboratorRequestBody("mygraph", "myUser");
@@ -187,13 +189,14 @@ class GafferClientTest {
     void addCollaboratorWithUsername_shouldThrowGaaSRestApiExceptionWhenError() throws ApiException, GaaSRestApiException {
         GaaSAddCollaboratorRequestBody gaaSAddCollaboratorRequestBody = new GaaSAddCollaboratorRequestBody("mygraph", "myUser");
         when(deploymentHandler.addGraphCollaboratorWithUsername(any(), any(), any(), any())).thenThrow(new ApiException("Failed to add collaborator label"));
-        assertThrows(GaaSRestApiException.class,() -> gafferClient.addCollaboratorWithUsername(gaaSAddCollaboratorRequestBody, "someUser"));
+        assertThrows(GaaSRestApiException.class, () -> gafferClient.addCollaboratorWithUsername(gaaSAddCollaboratorRequestBody, "someUser"));
     }
+
     @Test
     void addCollaborator_shouldThrowGaaSRestApiExceptionWhenError() throws ApiException, GaaSRestApiException {
         GaaSAddCollaboratorRequestBody gaaSAddCollaboratorRequestBody = new GaaSAddCollaboratorRequestBody("mygraph", "myUser");
         when(deploymentHandler.addGraphCollaborator(any(), any(), any())).thenThrow(new ApiException("Failed to add collaborator label"));
-        assertThrows(GaaSRestApiException.class,() -> gafferClient.addCollaborator(gaaSAddCollaboratorRequestBody));
+        assertThrows(GaaSRestApiException.class, () -> gafferClient.addCollaborator(gaaSAddCollaboratorRequestBody));
     }
 
     @Ignore

--- a/gaffer-as-a-service/gaas-rest/src/test/java/uk/gov/gchq/gaffer/gaas/client/GafferClientTest.java
+++ b/gaffer-as-a-service/gaas-rest/src/test/java/uk/gov/gchq/gaffer/gaas/client/GafferClientTest.java
@@ -158,10 +158,16 @@ class GafferClientTest {
     }
 
     @Test
-    void addCollaborator_shouldReturnTrueWhenSuccess() throws ApiException {
+    void addCollaborator_shouldReturnTrueWhenSuccess() throws ApiException, GaaSRestApiException {
         GaaSAddCollaboratorRequestBody gaaSAddCollaboratorRequestBody = new GaaSAddCollaboratorRequestBody("mygraph", "myUser");
         when(deploymentHandler.addGraphCollaborator(any(), any(), any())).thenReturn(true);
         assertTrue(gafferClient.addCollaborator(gaaSAddCollaboratorRequestBody));
+    }
+    @Test
+    void addCollaboratorWithUsername_shouldReturnTrueWhenSuccess() throws ApiException, GaaSRestApiException {
+        GaaSAddCollaboratorRequestBody gaaSAddCollaboratorRequestBody = new GaaSAddCollaboratorRequestBody("mygraph", "myUser");
+        when(deploymentHandler.addGraphCollaboratorWithUsername(any(), any(), any(), any())).thenReturn(true);
+        assertTrue(gafferClient.addCollaboratorWithUsername(gaaSAddCollaboratorRequestBody, "someUser"));
     }
 
     @Ignore

--- a/gaffer-as-a-service/gaas-rest/src/test/java/uk/gov/gchq/gaffer/gaas/client/GafferClientTest.java
+++ b/gaffer-as-a-service/gaas-rest/src/test/java/uk/gov/gchq/gaffer/gaas/client/GafferClientTest.java
@@ -87,7 +87,7 @@ class GafferClientTest {
         assertEquals("Failed to create Gaffer as it is null", exception.getTitle());
     }
 
-//create Gaffer with name
+    //create Gaffer with name
     @Test
     void createGraph_ShouldThrowGaaSRestApiException_WhenFailsToCreateGaffer() throws ApiException {
         GafferSpec gafferSpec = new GafferSpec();
@@ -160,7 +160,7 @@ class GafferClientTest {
     @Test
     void addCollaborator_shouldReturnTrueWhenSuccess() throws ApiException {
         GaaSAddCollaboratorRequestBody gaaSAddCollaboratorRequestBody = new GaaSAddCollaboratorRequestBody("mygraph", "myUser");
-        when(deploymentHandler.addGraphCollaborator(any(),any(),any())).thenReturn(true);
+        when(deploymentHandler.addGraphCollaborator(any(), any(), any())).thenReturn(true);
         assertTrue(gafferClient.addCollaborator(gaaSAddCollaboratorRequestBody));
     }
 

--- a/gaffer-as-a-service/gaas-rest/src/test/java/uk/gov/gchq/gaffer/gaas/client/GafferClientTest.java
+++ b/gaffer-as-a-service/gaas-rest/src/test/java/uk/gov/gchq/gaffer/gaas/client/GafferClientTest.java
@@ -126,6 +126,19 @@ class GafferClientTest {
 
         assertEquals(graphs, gaaSGraphs);
     }
+    @Test
+    void getGraphsWithUsername_ShouldReturnEmptyWhenNoGraphsExists() throws GaaSRestApiException {
+
+        List<GaaSGraph> graphs = new ArrayList<>();
+        try {
+            when(deploymentHandler.getDeploymentsByUsername(kubernetesClient, "myUser")).thenReturn(graphs);
+        } catch (ApiException e) {
+            e.printStackTrace();
+        }
+        List<GaaSGraph> gaaSGraphs = gafferClient.listUserCreatedGaffers("myUser");
+
+        assertEquals(graphs, gaaSGraphs);
+    }
 
     @Test
     void testGetAllNameSpaces_ShouldReturnMockedNamesSpaceResponse() throws ApiException, GaaSRestApiException {
@@ -168,6 +181,19 @@ class GafferClientTest {
         GaaSAddCollaboratorRequestBody gaaSAddCollaboratorRequestBody = new GaaSAddCollaboratorRequestBody("mygraph", "myUser");
         when(deploymentHandler.addGraphCollaboratorWithUsername(any(), any(), any(), any())).thenReturn(true);
         assertTrue(gafferClient.addCollaboratorWithUsername(gaaSAddCollaboratorRequestBody, "someUser"));
+    }
+
+    @Test
+    void addCollaboratorWithUsername_shouldThrowGaaSRestApiExceptionWhenError() throws ApiException, GaaSRestApiException {
+        GaaSAddCollaboratorRequestBody gaaSAddCollaboratorRequestBody = new GaaSAddCollaboratorRequestBody("mygraph", "myUser");
+        when(deploymentHandler.addGraphCollaboratorWithUsername(any(), any(), any(), any())).thenThrow(new ApiException("Failed to add collaborator label"));
+        assertThrows(GaaSRestApiException.class,() -> gafferClient.addCollaboratorWithUsername(gaaSAddCollaboratorRequestBody, "someUser"));
+    }
+    @Test
+    void addCollaborator_shouldThrowGaaSRestApiExceptionWhenError() throws ApiException, GaaSRestApiException {
+        GaaSAddCollaboratorRequestBody gaaSAddCollaboratorRequestBody = new GaaSAddCollaboratorRequestBody("mygraph", "myUser");
+        when(deploymentHandler.addGraphCollaborator(any(), any(), any())).thenThrow(new ApiException("Failed to add collaborator label"));
+        assertThrows(GaaSRestApiException.class,() -> gafferClient.addCollaborator(gaaSAddCollaboratorRequestBody));
     }
 
     @Ignore

--- a/gaffer-as-a-service/gaas-rest/src/test/java/uk/gov/gchq/gaffer/gaas/client/GafferClientTest.java
+++ b/gaffer-as-a-service/gaas-rest/src/test/java/uk/gov/gchq/gaffer/gaas/client/GafferClientTest.java
@@ -29,6 +29,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import uk.gov.gchq.gaffer.gaas.exception.GaaSRestApiException;
 import uk.gov.gchq.gaffer.gaas.handlers.DeploymentHandler;
+import uk.gov.gchq.gaffer.gaas.model.GaaSAddCollaboratorRequestBody;
 import uk.gov.gchq.gaffer.gaas.model.GaaSGraph;
 import uk.gov.gchq.gaffer.gaas.model.GraphUrl;
 import uk.gov.gchq.gaffer.gaas.model.v1.Gaffer;
@@ -41,6 +42,8 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static uk.gov.gchq.gaffer.gaas.util.ApiExceptionTestFactory.makeApiException_timeout;
 import static uk.gov.gchq.gaffer.gaas.util.Constants.INGRESS_API_PATH_KEY;
@@ -48,7 +51,7 @@ import static uk.gov.gchq.gaffer.gaas.util.Constants.INGRESS_HOST_KEY;
 
 
 @UnitTest
-@EnableKubernetesMockClient
+@EnableKubernetesMockClient(crud = true)
 class GafferClientTest {
 
     KubernetesClient kubernetesClient;
@@ -152,6 +155,13 @@ class GafferClientTest {
         when(deploymentHandler.onGafferDelete("gaffer", kubernetesClient)).thenReturn(true);
         assertDoesNotThrow(() -> gafferClient.deleteGaffer("gaffer"));
 
+    }
+
+    @Test
+    void addCollaborator_shouldReturnTrueWhenSuccess() throws ApiException {
+        GaaSAddCollaboratorRequestBody gaaSAddCollaboratorRequestBody = new GaaSAddCollaboratorRequestBody("mygraph", "myUser");
+        when(deploymentHandler.addGraphCollaborator(any(),any(),any())).thenReturn(true);
+        assertTrue(gafferClient.addCollaborator(gaaSAddCollaboratorRequestBody));
     }
 
     @Ignore

--- a/gaffer-as-a-service/gaas-rest/src/test/java/uk/gov/gchq/gaffer/gaas/controller/GraphControllerTest.java
+++ b/gaffer-as-a-service/gaas-rest/src/test/java/uk/gov/gchq/gaffer/gaas/controller/GraphControllerTest.java
@@ -24,6 +24,7 @@ import org.springframework.test.web.servlet.MvcResult;
 import uk.gov.gchq.gaffer.gaas.AbstractTest;
 import uk.gov.gchq.gaffer.gaas.exception.GaaSRestApiException;
 import uk.gov.gchq.gaffer.gaas.handlers.HelmValuesOverridesHandler;
+import uk.gov.gchq.gaffer.gaas.model.GaaSAddCollaboratorRequestBody;
 import uk.gov.gchq.gaffer.gaas.model.GaaSCreateRequestBody;
 import uk.gov.gchq.gaffer.gaas.model.GaaSGraph;
 import uk.gov.gchq.gaffer.gaas.model.GafferConfigSpec;
@@ -35,6 +36,7 @@ import uk.gov.gchq.gaffer.gaas.services.DeleteGraphService;
 import uk.gov.gchq.gaffer.gaas.services.GetGaaSGraphConfigsService;
 import uk.gov.gchq.gaffer.gaas.services.GetGaffersService;
 import uk.gov.gchq.gaffer.gaas.services.GetNamespacesService;
+import uk.gov.gchq.gaffer.gaas.services.UpdateGraphCollaboratorsService;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -65,6 +67,8 @@ class GraphControllerTest extends AbstractTest {
     private CreateFederatedStoreGraphService createFederatedStoreGraphService;
     @MockBean
     private DeleteGraphService deleteGraphService;
+    @MockBean
+    private UpdateGraphCollaboratorsService updateGraphCollaboratorsService;
     @MockBean
     private GetNamespacesService getNamespacesService;
     @MockBean
@@ -499,6 +503,24 @@ class GraphControllerTest extends AbstractTest {
 
         assertEquals(201, result.getResponse().getStatus());
         verify(createFederatedStoreGraphService, times(1)).createFederatedStore(any(GaaSCreateRequestBody.class));
+    }
+
+    @Test
+    void addCollaborator_shouldCallUpdateGraphCollaboratorService_andReturn202_whenSuccess() throws Exception {
+        final String request = "{" +
+                "\"graphId\":\"mygraph\"," +
+                "\"collaborator\":\"someUser\"" +
+                "}";
+        when(updateGraphCollaboratorsService.updateCollaborators(any(GaaSAddCollaboratorRequestBody.class))).thenReturn(true);
+        final MvcResult result = mvc.perform(post("/addCollaborator")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", token)
+                .header("username", "myUser")
+                .content(request))
+                .andReturn();
+        assertEquals(202, result.getResponse().getStatus());
+        verify(updateGraphCollaboratorsService, times(1)).updateCollaborators(any(GaaSAddCollaboratorRequestBody.class));
+
     }
 
     private LinkedHashMap<String, Object> getSchema() {

--- a/gaffer-as-a-service/gaas-rest/src/test/java/uk/gov/gchq/gaffer/gaas/controller/GraphControllerTest.java
+++ b/gaffer-as-a-service/gaas-rest/src/test/java/uk/gov/gchq/gaffer/gaas/controller/GraphControllerTest.java
@@ -515,11 +515,28 @@ class GraphControllerTest extends AbstractTest {
         final MvcResult result = mvc.perform(post("/addCollaborator")
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header("Authorization", token)
-                .header("username", "myUser")
+                .header("username", "test@test.com")
                 .content(request))
                 .andReturn();
         assertEquals(202, result.getResponse().getStatus());
         verify(updateGraphCollaboratorsService, times(1)).updateCollaborators(any(GaaSAddCollaboratorRequestBody.class));
+
+    }
+    @Test
+    void addCollaborator_shouldCallUpdateGraphCollaboratorWithUsernameService_andReturn202_whenSuccess() throws Exception {
+        final String request = "{" +
+                "\"graphId\":\"mygraph\"," +
+                "\"collaborator\":\"someUser\"" +
+                "}";
+        when(updateGraphCollaboratorsService.updateCollaboratorsWithUsername(any(GaaSAddCollaboratorRequestBody.class), any())).thenReturn(true);
+        final MvcResult result = mvc.perform(post("/addCollaborator")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", token)
+                .header("username", "someUser")
+                .content(request))
+                .andReturn();
+        assertEquals(202, result.getResponse().getStatus());
+        verify(updateGraphCollaboratorsService, times(1)).updateCollaboratorsWithUsername(any(GaaSAddCollaboratorRequestBody.class), any());
 
     }
 

--- a/gaffer-as-a-service/gaas-rest/src/test/java/uk/gov/gchq/gaffer/gaas/factories/GafferFactoryTest.java
+++ b/gaffer-as-a-service/gaas-rest/src/test/java/uk/gov/gchq/gaffer/gaas/factories/GafferFactoryTest.java
@@ -18,7 +18,6 @@ package uk.gov.gchq.gaffer.gaas.factories;
 
 import com.google.gson.Gson;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import uk.gov.gchq.gaffer.gaas.model.GaaSCreateRequestBody;
 import uk.gov.gchq.gaffer.gaas.model.v1.Gaffer;
@@ -31,6 +30,7 @@ import uk.gov.gchq.gaffer.proxystore.operation.handler.GetProxyUrlHandler;
 import uk.gov.gchq.gaffer.store.operation.declaration.OperationDeclaration;
 import uk.gov.gchq.gaffer.store.operation.declaration.OperationDeclarations;
 
+import javax.validation.constraints.NotNull;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;

--- a/gaffer-as-a-service/gaas-rest/src/test/java/uk/gov/gchq/gaffer/gaas/handlers/DeploymentHandlerTest.java
+++ b/gaffer-as-a-service/gaas-rest/src/test/java/uk/gov/gchq/gaffer/gaas/handlers/DeploymentHandlerTest.java
@@ -304,6 +304,25 @@ class DeploymentHandlerTest {
         assertEquals("No deployments of test to delete", log.get(0).getMessage());
     }
 
+    @Test
+    void shouldAddCollaboratorLabelWhenAddGraphCollaboratorCalled() throws ApiException {
+        // Given
+        ApiClient client = mock(ApiClient.class);
+        when(client.escapeString(anyString())).thenCallRealMethod();
+        DeploymentHandler handler = new DeploymentHandler(environment, kubernetesObjectFactory);
+        handler.setCoreV1Api(mock(CoreV1Api.class));
+        Map<String, String> labels = new HashMap<>();
+        labels.put("creator", "myUser");
+        labels.put("app.kubernetes.io/instance", "test");
+
+
+        kubernetesClient.apps().deployments().inNamespace("kai-dev").create(new DeploymentBuilder().withNewMetadata().withName("test-gaffer-api").withLabels(labels).endMetadata().build());
+        kubernetesClient.apps().deployments().inNamespace("kai-dev").create(new DeploymentBuilder().withNewMetadata().withName("test-gaffer-ui").withLabels(labels).endMetadata().build());
+        handler.addGraphCollaborator("test", kubernetesClient, "someUser");
+
+        assertEquals("someUser",kubernetesClient.apps().deployments().inNamespace("kai-dev").list().getItems().get(0).getMetadata().getLabels().get("collaborator/someUser"));
+    }
+
 
     private Gaffer getGaffer() {
         GafferSpec gafferSpec = new GafferSpec();

--- a/gaffer-as-a-service/gaas-rest/src/test/java/uk/gov/gchq/gaffer/gaas/handlers/DeploymentHandlerTest.java
+++ b/gaffer-as-a-service/gaas-rest/src/test/java/uk/gov/gchq/gaffer/gaas/handlers/DeploymentHandlerTest.java
@@ -16,7 +16,6 @@
 
 package uk.gov.gchq.gaffer.gaas.handlers;
 
-import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.fabric8.kubernetes.api.model.apps.DeploymentList;
@@ -321,9 +320,9 @@ class DeploymentHandlerTest {
         kubernetesClient.apps().deployments().inNamespace("kai-dev").create(new DeploymentBuilder().withNewMetadata().withName("test-gaffer-ui").withLabels(labels).endMetadata().build());
         handler.addGraphCollaborator("test", kubernetesClient, "someUser");
 
-        assertEquals("someUser",kubernetesClient.apps().deployments().inNamespace("kai-dev").list().getItems().get(0).getMetadata().getLabels().get("collaborator/someUser"));
+        assertEquals("someUser", kubernetesClient.apps().deployments().inNamespace("kai-dev").list().getItems().get(0).getMetadata().getLabels().get("collaborator/someUser"));
     }
-    
+
 
     private Gaffer getGaffer() {
         GafferSpec gafferSpec = new GafferSpec();

--- a/gaffer-as-a-service/gaas-rest/src/test/java/uk/gov/gchq/gaffer/gaas/handlers/DeploymentHandlerTest.java
+++ b/gaffer-as-a-service/gaas-rest/src/test/java/uk/gov/gchq/gaffer/gaas/handlers/DeploymentHandlerTest.java
@@ -16,6 +16,7 @@
 
 package uk.gov.gchq.gaffer.gaas.handlers;
 
+import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.fabric8.kubernetes.api.model.apps.DeploymentList;
@@ -322,7 +323,7 @@ class DeploymentHandlerTest {
 
         assertEquals("someUser",kubernetesClient.apps().deployments().inNamespace("kai-dev").list().getItems().get(0).getMetadata().getLabels().get("collaborator/someUser"));
     }
-
+    
 
     private Gaffer getGaffer() {
         GafferSpec gafferSpec = new GafferSpec();

--- a/gaffer-as-a-service/gaas-rest/src/test/java/uk/gov/gchq/gaffer/gaas/handlers/DeploymentHandlerTest.java
+++ b/gaffer-as-a-service/gaas-rest/src/test/java/uk/gov/gchq/gaffer/gaas/handlers/DeploymentHandlerTest.java
@@ -321,6 +321,8 @@ class DeploymentHandlerTest {
         handler.addGraphCollaborator("test", kubernetesClient, "someUser");
 
         assertEquals("someUser", kubernetesClient.apps().deployments().inNamespace("kai-dev").list().getItems().get(0).getMetadata().getLabels().get("collaborator/someUser"));
+        assertEquals("someUser", kubernetesClient.apps().deployments().inNamespace("kai-dev").list().getItems().get(1).getMetadata().getLabels().get("collaborator/someUser"));
+
     }
 
 

--- a/gaffer-as-a-service/gaas-rest/src/test/java/uk/gov/gchq/gaffer/gaas/services/UpdateGraphCollaboratorServiceTest.java
+++ b/gaffer-as-a-service/gaas-rest/src/test/java/uk/gov/gchq/gaffer/gaas/services/UpdateGraphCollaboratorServiceTest.java
@@ -41,4 +41,14 @@ public class UpdateGraphCollaboratorServiceTest {
 
         assertTrue(actual);
     }
+
+    @Test
+    void shouldReturnTrueWhenAddingCollaboratorWithUsernameSuccessful() {
+        GaaSAddCollaboratorRequestBody gaaSAddCollaboratorRequestBody = new GaaSAddCollaboratorRequestBody("myGraph", "myUser");
+        when(gafferClient.addCollaboratorWithUsername(gaaSAddCollaboratorRequestBody, "myUser")).thenReturn(true);
+
+        final boolean actual = updateGraphCollaboratorsService.updateCollaboratorsWithUsername(gaaSAddCollaboratorRequestBody, "myUser");
+
+        assertTrue(actual);
+    }
 }

--- a/gaffer-as-a-service/gaas-rest/src/test/java/uk/gov/gchq/gaffer/gaas/services/UpdateGraphCollaboratorServiceTest.java
+++ b/gaffer-as-a-service/gaas-rest/src/test/java/uk/gov/gchq/gaffer/gaas/services/UpdateGraphCollaboratorServiceTest.java
@@ -1,0 +1,29 @@
+package uk.gov.gchq.gaffer.gaas.services;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import uk.gov.gchq.gaffer.gaas.client.GafferClient;
+import uk.gov.gchq.gaffer.gaas.model.GaaSAddCollaboratorRequestBody;
+import uk.gov.gchq.gaffer.gaas.util.UnitTest;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@UnitTest
+public class UpdateGraphCollaboratorServiceTest {
+    @MockBean
+    GafferClient gafferClient;
+    @Autowired
+    private UpdateGraphCollaboratorsService updateGraphCollaboratorsService;
+
+    @Test
+    void shouldReturnTrueWhenAddingCollaboratorSuccessful(){
+        GaaSAddCollaboratorRequestBody gaaSAddCollaboratorRequestBody = new GaaSAddCollaboratorRequestBody("myGraph","myUser");
+        when(gafferClient.addCollaborator(gaaSAddCollaboratorRequestBody)).thenReturn(true);
+
+        final boolean actual = updateGraphCollaboratorsService.updateCollaborators(gaaSAddCollaboratorRequestBody);
+
+        assertTrue(actual);
+    }
+}

--- a/gaffer-as-a-service/gaas-rest/src/test/java/uk/gov/gchq/gaffer/gaas/services/UpdateGraphCollaboratorServiceTest.java
+++ b/gaffer-as-a-service/gaas-rest/src/test/java/uk/gov/gchq/gaffer/gaas/services/UpdateGraphCollaboratorServiceTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package uk.gov.gchq.gaffer.gaas.services;
 
 import org.junit.jupiter.api.Test;
@@ -18,8 +33,8 @@ public class UpdateGraphCollaboratorServiceTest {
     private UpdateGraphCollaboratorsService updateGraphCollaboratorsService;
 
     @Test
-    void shouldReturnTrueWhenAddingCollaboratorSuccessful(){
-        GaaSAddCollaboratorRequestBody gaaSAddCollaboratorRequestBody = new GaaSAddCollaboratorRequestBody("myGraph","myUser");
+    void shouldReturnTrueWhenAddingCollaboratorSuccessful() {
+        GaaSAddCollaboratorRequestBody gaaSAddCollaboratorRequestBody = new GaaSAddCollaboratorRequestBody("myGraph", "myUser");
         when(gafferClient.addCollaborator(gaaSAddCollaboratorRequestBody)).thenReturn(true);
 
         final boolean actual = updateGraphCollaboratorsService.updateCollaborators(gaaSAddCollaboratorRequestBody);

--- a/gaffer-as-a-service/gaas-rest/src/test/java/uk/gov/gchq/gaffer/gaas/services/UpdateGraphCollaboratorServiceTest.java
+++ b/gaffer-as-a-service/gaas-rest/src/test/java/uk/gov/gchq/gaffer/gaas/services/UpdateGraphCollaboratorServiceTest.java
@@ -34,7 +34,7 @@ public class UpdateGraphCollaboratorServiceTest {
     private UpdateGraphCollaboratorsService updateGraphCollaboratorsService;
 
     @Test
-    void shouldReturnTrueWhenAddingCollaboratorSuccessful() {
+    void shouldReturnTrueWhenAddingCollaboratorSuccessful() throws GaaSRestApiException {
         GaaSAddCollaboratorRequestBody gaaSAddCollaboratorRequestBody = new GaaSAddCollaboratorRequestBody("myGraph", "myUser");
         when(gafferClient.addCollaborator(gaaSAddCollaboratorRequestBody)).thenReturn(true);
 

--- a/gaffer-as-a-service/gaas-rest/src/test/java/uk/gov/gchq/gaffer/gaas/services/UpdateGraphCollaboratorServiceTest.java
+++ b/gaffer-as-a-service/gaas-rest/src/test/java/uk/gov/gchq/gaffer/gaas/services/UpdateGraphCollaboratorServiceTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import uk.gov.gchq.gaffer.gaas.client.GafferClient;
+import uk.gov.gchq.gaffer.gaas.exception.GaaSRestApiException;
 import uk.gov.gchq.gaffer.gaas.model.GaaSAddCollaboratorRequestBody;
 import uk.gov.gchq.gaffer.gaas.util.UnitTest;
 
@@ -43,7 +44,7 @@ public class UpdateGraphCollaboratorServiceTest {
     }
 
     @Test
-    void shouldReturnTrueWhenAddingCollaboratorWithUsernameSuccessful() {
+    void shouldReturnTrueWhenAddingCollaboratorWithUsernameSuccessful() throws GaaSRestApiException {
         GaaSAddCollaboratorRequestBody gaaSAddCollaboratorRequestBody = new GaaSAddCollaboratorRequestBody("myGraph", "myUser");
         when(gafferClient.addCollaboratorWithUsername(gaaSAddCollaboratorRequestBody, "myUser")).thenReturn(true);
 

--- a/gaffer-as-a-service/gaas-rest/src/test/java/uk/gov/gchq/gaffer/gaas/util/UnitTestConfig.java
+++ b/gaffer-as-a-service/gaas-rest/src/test/java/uk/gov/gchq/gaffer/gaas/util/UnitTestConfig.java
@@ -34,6 +34,7 @@ import uk.gov.gchq.gaffer.gaas.services.DeleteGraphService;
 import uk.gov.gchq.gaffer.gaas.services.GetGaaSGraphConfigsService;
 import uk.gov.gchq.gaffer.gaas.services.GetGaffersService;
 import uk.gov.gchq.gaffer.gaas.services.GetNamespacesService;
+import uk.gov.gchq.gaffer.gaas.services.UpdateGraphCollaboratorsService;
 
 import static org.mockito.Mockito.mock;
 
@@ -91,6 +92,11 @@ public class UnitTestConfig {
     @Bean
     public GetGaaSGraphConfigsService getStoreTypesService() {
         return new GetGaaSGraphConfigsService();
+    }
+
+    @Bean
+    public UpdateGraphCollaboratorsService updateGraphCollaboratorsService() {
+        return new UpdateGraphCollaboratorsService();
     }
 
     @Bean

--- a/gaffer-as-a-service/gaas-ui/src/components/add-collaborator/add-collaborator.tsx
+++ b/gaffer-as-a-service/gaas-ui/src/components/add-collaborator/add-collaborator.tsx
@@ -27,163 +27,60 @@ import {
     Zoom,
 } from "@material-ui/core";
 import AddCircleOutlineOutlinedIcon from "@material-ui/icons/AddCircleOutlineOutlined";
-import React from "react";
+import React, { useState } from "react";
 import { AlertType, NotificationAlert } from "../alerts/notification-alert";
-import { TransitionProps } from "@material-ui/core/transitions";
 import { Copyright } from "../copyright/copyright";
 import { GaaSAPIErrorResponse } from "../../rest/http-message-interfaces/error-response-interface";
 import DOMPurify from "dompurify";
 import { encode } from "html-entities";
 import { AddCollaboratorRepo } from "../../rest/repositories/add-collaborator-repo";
 import GraphIdUsernameInput from "./graph-id-collaborator";
+import { useLocation } from "react-router-dom";
 
-interface IState {
-    graphId: string;
-    username: string;
-    usernameIsValid: boolean;
-    root: string;
-    outcome: AlertType | undefined;
-    outcomeMessage: string;
-}
+export default function AddCollaborator(props: any) {
+    const location: any = useLocation();
+    const [graphId, setGraphId] = useState(location.state.graphId);
+    const [username, setUsername] = useState("");
+    const [usernameIsValid, setUsernameIsValid] = useState(false);
+    const [outcome, setOutcome] = React.useState<AlertType | undefined>();
+    const [outcomeMessage, setOutcomeMessage] = useState("");
 
-const Transition = React.forwardRef((props: TransitionProps & { children?: React.ReactElement<any, any> }) => (
-    <Slide direction="up" {...props} />
-));
-
-export default class AddCollaborator extends React.Component<{}, IState> {
-    constructor(props: object) {
-        super(props);
-        this.state = {
-            graphId: "",
-            username: "",
-            usernameIsValid: false,
-            root: "",
-            outcome: undefined,
-            outcomeMessage: "",
-        };
-    }
-
-    public async componentDidMount() {}
-
-    private async submitAddCollaborator() {
-        //TODO: separate functions
-        const { graphId, username } = this.state;
+    const submitAddCollaborator = async () => {
+        setGraphId(graphId);
+        setUsername(username);
 
         try {
             await new AddCollaboratorRepo().addCollaborator(
                 encode(DOMPurify.sanitize(graphId)),
                 encode(DOMPurify.sanitize(username))
             );
-            this.setState({
-                outcome: AlertType.SUCCESS,
-                outcomeMessage: `${graphId} was successfully added collaborator`,
-            });
-            this.resetForm();
+
+            setOutcome(AlertType.SUCCESS);
+            setOutcomeMessage(`${graphId} was successfully added collaborator`);
+
+            resetForm();
         } catch (e: any) {
-            this.setState({
-                outcome: AlertType.FAILED,
-                outcomeMessage: `Failed to Add '${graphId}' Graph. ${(e as GaaSAPIErrorResponse).title}: ${
+            setOutcome(AlertType.FAILED);
+            setOutcomeMessage(
+                `Failed to Add '${graphId}' Graph. ${(e as GaaSAPIErrorResponse).title}: ${
                     (e as GaaSAPIErrorResponse).detail
-                }`,
-            });
+                }`
+            );
         }
-    }
+    };
 
-    private resetForm() {
-        this.setState({
-            graphId: "",
-            username: "",
-        });
-    }
+    const resetForm = () => {
+        setUsername("");
+    };
 
-    private disableSubmitButton(): boolean {
-        const { username, usernameIsValid } = this.state;
-        return !username || !usernameIsValid;
-    }
+    const setUsernameValid = (username: string, usernameIsValid: boolean) => {
+        setUsernameIsValid(usernameIsValid);
+        setUsername(username);
+    };
 
-    public render() {
-        return (
-            <main aria-label="add-collaborator-Page" id={"add-collaborator-page"}>
-                {this.state.outcome && (
-                    <NotificationAlert alertType={this.state.outcome} message={this.state.outcomeMessage} />
-                )}
-                <Toolbar />
+    const disableSubmitButton = () => !username || !usernameIsValid;
 
-                <Grid container justify="center">
-                    <Container maxWidth="md">
-                        <CssBaseline />
-                        <div className={this.classes.paper}>
-                            <Grid
-                                item
-                                xs={12}
-                                container
-                                direction="row"
-                                justify="center"
-                                alignItems="center"
-                                style={{ margin: 10 }}
-                            >
-                                <Box my={4}>
-                                    <Typography
-                                        variant="h4"
-                                        align={"center"}
-                                        id={"add-collaborator-title"}
-                                        aria-label={"add-collaborato-title"}
-                                    >
-                                        Add Collaborator
-                                    </Typography>
-                                </Box>
-                            </Grid>
-                            <form className={this.classes.form} noValidate>
-                                <Grid container spacing={1}>
-                                    <GraphIdUsernameInput
-                                        graphIdValue={this.state.graphId}
-                                        usernameValue={this.state.username}
-                                        onChangeUsername={(username, usernameIsValid) =>
-                                            this.setState({ username, usernameIsValid })
-                                        }
-                                    />
-
-                                    <Grid
-                                        item
-                                        xs={12}
-                                        container
-                                        direction="row"
-                                        justify="flex-end"
-                                        alignItems="center"
-                                    />
-                                </Grid>
-                            </form>
-                        </div>
-                    </Container>
-                    <Grid container style={{ margin: 10 }} direction="row" justify="center" alignItems="center">
-                        <Button
-                            id="add-collaborator-button"
-                            onClick={() => {
-                                this.submitAddCollaborator();
-                            }}
-                            startIcon={<AddCircleOutlineOutlinedIcon />}
-                            type="submit"
-                            variant="contained"
-                            color="primary"
-                            className={this.classes.submit}
-                            disabled={this.disableSubmitButton()}
-                        >
-                            Add Collaborator
-                        </Button>
-                    </Grid>
-                    <Box pt={4}>
-                        <Copyright />
-                    </Box>
-                </Grid>
-            </main>
-        );
-    }
-
-    private classes: any = makeStyles((theme) => ({
-        root: {
-            width: "100%",
-            marginTop: 40,
-        },
+    const classes: any = makeStyles((theme) => ({
         paper: {
             marginTop: theme.spacing(2),
             display: "flex",
@@ -204,9 +101,73 @@ export default class AddCollaborator extends React.Component<{}, IState> {
         button: {
             margin: "10px",
         },
-        previewChip: {
-            minWidth: 160,
-            maxWidth: 210,
-        },
     }));
+
+    return (
+        <main aria-label="add-collaborator-Page" id={"add-collaborator-page"}>
+            {outcome && <NotificationAlert alertType={outcome} message={outcomeMessage} />}
+            <Toolbar />
+            <Toolbar />
+
+            <Grid container justify="center">
+                <Container maxWidth="md">
+                    <CssBaseline />
+                    <div className={classes.paper}>
+                        <Grid
+                            item
+                            xs={12}
+                            container
+                            direction="row"
+                            justify="center"
+                            alignItems="center"
+                            style={{ margin: 10 }}
+                        >
+                            <Box my={4}>
+                                <Typography
+                                    variant="h4"
+                                    align={"center"}
+                                    id={"add-collaborator-title"}
+                                    aria-label={"add-collaborato-title"}
+                                >
+                                    Add Collaborator
+                                </Typography>
+                            </Box>
+                        </Grid>
+                        <form className={classes.form} noValidate>
+                            <Grid container spacing={1}>
+                                <GraphIdUsernameInput
+                                    graphIdValue={DOMPurify.sanitize(graphId)}
+                                    usernameValue={username}
+                                    onChangeUsername={(username, usernameIsValid) =>
+                                        setUsernameValid(username, usernameIsValid)
+                                    }
+                                />
+
+                                <Grid item xs={12} container direction="row" justify="flex-end" alignItems="center" />
+                            </Grid>
+                        </form>
+                    </div>
+                </Container>
+                <Grid container style={{ margin: 10 }} direction="row" justify="center" alignItems="center">
+                    <Button
+                        id="add-collaborator-button"
+                        onClick={() => {
+                            submitAddCollaborator();
+                        }}
+                        startIcon={<AddCircleOutlineOutlinedIcon />}
+                        type="submit"
+                        variant="contained"
+                        color="primary"
+                        className={classes.submit}
+                        disabled={disableSubmitButton()}
+                    >
+                        Add Collaborator
+                    </Button>
+                </Grid>
+                <Box pt={4}>
+                    <Copyright />
+                </Box>
+            </Grid>
+        </main>
+    );
 }

--- a/gaffer-as-a-service/gaas-ui/src/components/add-collaborator/add-collaborator.tsx
+++ b/gaffer-as-a-service/gaas-ui/src/components/add-collaborator/add-collaborator.tsx
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2021-2022 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    Box,
+    Button,
+    Container,
+    CssBaseline,
+    Grid,
+    makeStyles,
+    Slide,
+    Toolbar,
+    Typography,
+    Zoom,
+} from "@material-ui/core";
+import AddCircleOutlineOutlinedIcon from "@material-ui/icons/AddCircleOutlineOutlined";
+import React from "react";
+import { AlertType, NotificationAlert } from "../alerts/notification-alert";
+import { TransitionProps } from "@material-ui/core/transitions";
+import { Copyright } from "../copyright/copyright";
+import { GaaSAPIErrorResponse } from "../../rest/http-message-interfaces/error-response-interface";
+import DOMPurify from "dompurify";
+import { encode } from "html-entities";
+import { AddCollaboratorRepo } from "../../rest/repositories/add-collaborator-repo";
+import GraphIdCollaboratorInput from "./graph-id-collaborator";
+
+interface IState {
+    graphId: string;
+    collaborator: string;
+    graphIdIsValid: boolean;
+    graphCollaboratorIsValid: boolean;
+    root: string;
+    dialogIsOpen: boolean;
+    outcome: AlertType | undefined;
+    outcomeMessage: string;
+}
+
+const Transition = React.forwardRef((props: TransitionProps & { children?: React.ReactElement<any, any> }) => (
+    <Slide direction="up" {...props} />
+));
+
+export default class AddCollaborator extends React.Component<{}, IState> {
+    constructor(props: object) {
+        super(props);
+        this.state = {
+            graphId: "",
+            collaborator: "",
+            graphIdIsValid: false,
+            graphCollaboratorIsValid: false,
+            root: "",
+            dialogIsOpen: false,
+            outcome: undefined,
+            outcomeMessage: "",
+        };
+    }
+
+    public async componentDidMount() {}
+
+    private async submitAddCollaborator() {
+        //TODO: separate functions
+        const { graphId } = this.state;
+
+        try {
+            await new AddCollaboratorRepo().addCollaborator(encode(DOMPurify.sanitize(graphId)));
+            this.setState({
+                outcome: AlertType.SUCCESS,
+                outcomeMessage: `${graphId} was successfully added collaborator`,
+            });
+            this.resetForm();
+        } catch (e: any) {
+            this.setState({
+                outcome: AlertType.FAILED,
+                outcomeMessage: `Failed to Add '${graphId}' Graph. ${(e as GaaSAPIErrorResponse).title}: ${
+                    (e as GaaSAPIErrorResponse).detail
+                }`,
+            });
+        }
+    }
+
+    private resetForm() {
+        this.setState({
+            graphId: "",
+            collaborator: "",
+        });
+    }
+
+    private disableSubmitButton(): boolean {
+        const { graphId } = this.state;
+        return !graphId;
+    }
+
+    public render() {
+        return (
+            <main aria-label="add-collaborator-Page" id={"add-collaborator-page"}>
+                {this.state.outcome && (
+                    <NotificationAlert alertType={this.state.outcome} message={this.state.outcomeMessage} />
+                )}
+                <Toolbar />
+
+                <Grid container justify="center">
+                    <Container maxWidth="md">
+                        <CssBaseline />
+                        <div className={this.classes.paper}>
+                            <Grid
+                                item
+                                xs={12}
+                                container
+                                direction="row"
+                                justify="center"
+                                alignItems="center"
+                                style={{ margin: 10 }}
+                            >
+                                <Box my={4}>
+                                    <Typography
+                                        variant="h4"
+                                        align={"center"}
+                                        id={"add-collaborator-title"}
+                                        aria-label={"add-collaborato-title"}
+                                    >
+                                        Add Collaborator
+                                    </Typography>
+                                </Box>
+                            </Grid>
+                            <form className={this.classes.form} noValidate>
+                                <Grid container spacing={1}>
+                                    <GraphIdCollaboratorInput
+                                        graphIdValue={this.state.graphId}
+                                        onChangeGraphId={(graphId, graphIdIsValid) =>
+                                            this.setState({ graphId, graphIdIsValid })
+                                        }
+                                        collaboratorValue={this.state.collaborator}
+                                        onChangeCollaborator={(collaborator, graphCollaboratorIsValid) =>
+                                            this.setState({ collaborator, graphCollaboratorIsValid })
+                                        }
+                                    />
+
+                                    <Grid
+                                        item
+                                        xs={12}
+                                        container
+                                        direction="row"
+                                        justify="flex-end"
+                                        alignItems="center"
+                                    />
+                                </Grid>
+                            </form>
+                        </div>
+                    </Container>
+                    <Grid container style={{ margin: 10 }} direction="row" justify="center" alignItems="center">
+                        <Button
+                            id="add-collaborator-button"
+                            onClick={() => {
+                                this.submitAddCollaborator();
+                            }}
+                            startIcon={<AddCircleOutlineOutlinedIcon />}
+                            type="submit"
+                            variant="contained"
+                            color="primary"
+                            className={this.classes.submit}
+                            disabled={this.disableSubmitButton()}
+                        >
+                            Add Collaborator
+                        </Button>
+                    </Grid>
+                    <Box pt={4}>
+                        <Copyright />
+                    </Box>
+                </Grid>
+            </main>
+        );
+    }
+
+    private classes: any = makeStyles((theme) => ({
+        root: {
+            width: "100%",
+            marginTop: 40,
+        },
+        paper: {
+            marginTop: theme.spacing(2),
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+        },
+        avatar: {
+            margin: theme.spacing(1),
+            backgroundColor: theme.palette.secondary.main,
+        },
+        form: {
+            width: "100%", // Fix IE 11 issue.
+            marginTop: theme.spacing(3),
+        },
+        submit: {
+            margin: theme.spacing(3, 0, 2),
+        },
+        button: {
+            margin: "10px",
+        },
+        previewChip: {
+            minWidth: 160,
+            maxWidth: 210,
+        },
+    }));
+}

--- a/gaffer-as-a-service/gaas-ui/src/components/add-collaborator/add-collaborator.tsx
+++ b/gaffer-as-a-service/gaas-ui/src/components/add-collaborator/add-collaborator.tsx
@@ -14,18 +14,7 @@
  * limitations under the License.
  */
 
-import {
-    Box,
-    Button,
-    Container,
-    CssBaseline,
-    Grid,
-    makeStyles,
-    Slide,
-    Toolbar,
-    Typography,
-    Zoom,
-} from "@material-ui/core";
+import { Box, Button, Container, CssBaseline, Grid, makeStyles, Toolbar, Typography } from "@material-ui/core";
 import AddCircleOutlineOutlinedIcon from "@material-ui/icons/AddCircleOutlineOutlined";
 import React, { useState } from "react";
 import { AlertType, NotificationAlert } from "../alerts/notification-alert";
@@ -73,7 +62,7 @@ export default function AddCollaborator(props: any) {
         setUsername("");
     };
 
-    const setUsernameValid = (username: string, usernameIsValid: boolean) => {
+    const updateUsername = (username: string, usernameIsValid: boolean) => {
         setUsernameIsValid(usernameIsValid);
         setUsername(username);
     };
@@ -139,7 +128,7 @@ export default function AddCollaborator(props: any) {
                                     graphIdValue={DOMPurify.sanitize(graphId)}
                                     usernameValue={username}
                                     onChangeUsername={(username, usernameIsValid) =>
-                                        setUsernameValid(username, usernameIsValid)
+                                        updateUsername(username, usernameIsValid)
                                     }
                                 />
 

--- a/gaffer-as-a-service/gaas-ui/src/components/add-collaborator/add-collaborator.tsx
+++ b/gaffer-as-a-service/gaas-ui/src/components/add-collaborator/add-collaborator.tsx
@@ -55,11 +55,9 @@ export default class AddCollaborator extends React.Component<{}, IState> {
         super(props);
         this.state = {
             graphId: "",
-            collaborator: "",
-            graphIdIsValid: false,
-            graphCollaboratorIsValid: false,
+            username: "",
+            usernameIsValid: false,
             root: "",
-            dialogIsOpen: false,
             outcome: undefined,
             outcomeMessage: "",
         };

--- a/gaffer-as-a-service/gaas-ui/src/components/add-collaborator/add-collaborator.tsx
+++ b/gaffer-as-a-service/gaas-ui/src/components/add-collaborator/add-collaborator.tsx
@@ -35,15 +35,13 @@ import { GaaSAPIErrorResponse } from "../../rest/http-message-interfaces/error-r
 import DOMPurify from "dompurify";
 import { encode } from "html-entities";
 import { AddCollaboratorRepo } from "../../rest/repositories/add-collaborator-repo";
-import GraphIdCollaboratorInput from "./graph-id-collaborator";
+import GraphIdUsernameInput from "./graph-id-collaborator";
 
 interface IState {
     graphId: string;
-    collaborator: string;
-    graphIdIsValid: boolean;
-    graphCollaboratorIsValid: boolean;
+    username: string;
+    usernameIsValid: boolean;
     root: string;
-    dialogIsOpen: boolean;
     outcome: AlertType | undefined;
     outcomeMessage: string;
 }
@@ -71,10 +69,13 @@ export default class AddCollaborator extends React.Component<{}, IState> {
 
     private async submitAddCollaborator() {
         //TODO: separate functions
-        const { graphId } = this.state;
+        const { graphId, username } = this.state;
 
         try {
-            await new AddCollaboratorRepo().addCollaborator(encode(DOMPurify.sanitize(graphId)));
+            await new AddCollaboratorRepo().addCollaborator(
+                encode(DOMPurify.sanitize(graphId)),
+                encode(DOMPurify.sanitize(username))
+            );
             this.setState({
                 outcome: AlertType.SUCCESS,
                 outcomeMessage: `${graphId} was successfully added collaborator`,
@@ -93,13 +94,13 @@ export default class AddCollaborator extends React.Component<{}, IState> {
     private resetForm() {
         this.setState({
             graphId: "",
-            collaborator: "",
+            username: "",
         });
     }
 
     private disableSubmitButton(): boolean {
-        const { graphId } = this.state;
-        return !graphId;
+        const { username, usernameIsValid } = this.state;
+        return !username || !usernameIsValid;
     }
 
     public render() {
@@ -136,14 +137,11 @@ export default class AddCollaborator extends React.Component<{}, IState> {
                             </Grid>
                             <form className={this.classes.form} noValidate>
                                 <Grid container spacing={1}>
-                                    <GraphIdCollaboratorInput
+                                    <GraphIdUsernameInput
                                         graphIdValue={this.state.graphId}
-                                        onChangeGraphId={(graphId, graphIdIsValid) =>
-                                            this.setState({ graphId, graphIdIsValid })
-                                        }
-                                        collaboratorValue={this.state.collaborator}
-                                        onChangeCollaborator={(collaborator, graphCollaboratorIsValid) =>
-                                            this.setState({ collaborator, graphCollaboratorIsValid })
+                                        usernameValue={this.state.username}
+                                        onChangeUsername={(username, usernameIsValid) =>
+                                            this.setState({ username, usernameIsValid })
                                         }
                                     />
 

--- a/gaffer-as-a-service/gaas-ui/src/components/add-collaborator/add-collaborator.tsx
+++ b/gaffer-as-a-service/gaas-ui/src/components/add-collaborator/add-collaborator.tsx
@@ -35,7 +35,6 @@ export default function AddCollaborator(props: any) {
     const [outcomeMessage, setOutcomeMessage] = useState("");
 
     const submitAddCollaborator = async () => {
-        setGraphId(graphId);
         setUsername(username);
 
         try {

--- a/gaffer-as-a-service/gaas-ui/src/components/add-collaborator/graph-id-collaborator.tsx
+++ b/gaffer-as-a-service/gaas-ui/src/components/add-collaborator/graph-id-collaborator.tsx
@@ -39,11 +39,12 @@ export default function GraphIdUsernameInput(props: IProps): ReactElement {
                     id="graph-id"
                     aria-label="graph-id-input"
                     variant="outlined"
-                    value="testgraph"
+                    value={graphIdValue}
                     required
                     fullWidth
                     autoFocus
                     name="graph-id"
+                    disabled
                 />
             </Grid>
             <Grid item xs={12} container direction="row" justify="flex-end" alignItems="center"></Grid>

--- a/gaffer-as-a-service/gaas-ui/src/components/add-collaborator/graph-id-collaborator.tsx
+++ b/gaffer-as-a-service/gaas-ui/src/components/add-collaborator/graph-id-collaborator.tsx
@@ -48,7 +48,7 @@ export default function GraphIdUsernameInput(props: IProps): ReactElement {
                 />
             </Grid>
             <Grid item xs={12} container direction="row" justify="flex-end" alignItems="center"></Grid>
-            <Grid item xs={12}>
+            <Grid item xs={12} id={"id-username-fields"} aria-label="id-username-fields">
                 <InputLabel aria-label="username-input-label" id="username-input-label" required>
                     User name
                 </InputLabel>
@@ -60,15 +60,14 @@ export default function GraphIdUsernameInput(props: IProps): ReactElement {
                         id: "username-input",
                         "aria-label": "username-input",
                     }}
+                    variant="outlined"
                     value={usernameValue}
                     error={usernameErrorHelperText.length > 0}
                     required
-                    multiline
-                    autoFocus
                     fullWidth
-                    name="username"
-                    variant="outlined"
+                    autoFocus
                     helperText={usernameErrorHelperText}
+                    name="username"
                     onChange={(event) => {
                         const regex = new RegExp("^[ A-Za-z0-9_@.-]*$");
                         if (regex.test(event.target.value)) {

--- a/gaffer-as-a-service/gaas-ui/src/components/add-collaborator/graph-id-collaborator.tsx
+++ b/gaffer-as-a-service/gaas-ui/src/components/add-collaborator/graph-id-collaborator.tsx
@@ -38,6 +38,12 @@ export default function GraphIdUsernameInput(props: IProps): ReactElement {
                 <TextField
                     id="graph-id"
                     aria-label="graph-id-input"
+                    inputProps={{
+                        readOnly: true,
+                        name: "graph id",
+                        id: "graph-id-input",
+                        "aria-label": "graph-id-input",
+                    }}
                     variant="outlined"
                     value={graphIdValue}
                     required

--- a/gaffer-as-a-service/gaas-ui/src/components/add-collaborator/graph-id-collaborator.tsx
+++ b/gaffer-as-a-service/gaas-ui/src/components/add-collaborator/graph-id-collaborator.tsx
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2021-2022 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { ReactElement, useState } from "react";
+import Grid from "@material-ui/core/Grid";
+import TextField from "@material-ui/core/TextField";
+import { InputLabel } from "@material-ui/core";
+
+interface IProps {
+    graphIdValue: string;
+    collaboratorValue: string;
+    onChangeGraphId(graphId: string, graphIdIsValid: boolean): void;
+    onChangeCollaborator(graphId: string, graphCollaboratorIsValid: boolean): void;
+}
+
+export default function GraphIdCollaboratorInput(props: IProps): ReactElement {
+    const { graphIdValue, collaboratorValue, onChangeGraphId, onChangeCollaborator } = props;
+    const [graphIdErrorHelperText, setGraphIdErrorHelperText] = useState("");
+    const [collaboratorErrorHelperText, setCollaboratorErrorHelperText] = useState("");
+
+    return (
+        <>
+            <Grid item xs={12} id={"id-collaborator-fields"} aria-label="id-collaborator-fields">
+                <InputLabel aria-label="graph-id-input-label" id="graph-id-input-label" required>
+                    Graph Id
+                </InputLabel>
+                <TextField
+                    id="graph-id"
+                    inputProps={{
+                        name: "Graph ID",
+                        id: "graph-id-input",
+                        "aria-label": "graph-id-input",
+                    }}
+                    aria-label="graph-id-input"
+                    variant="outlined"
+                    value={graphIdValue}
+                    error={graphIdErrorHelperText.length > 0}
+                    required
+                    fullWidth
+                    autoFocus
+                    helperText={graphIdErrorHelperText}
+                    name="graph-id"
+                    onChange={(event) => {
+                        const regex = new RegExp("^[a-z0-9]*$");
+                        if (regex.test(event.target.value)) {
+                            onChangeGraphId(event.target.value, true);
+                            setGraphIdErrorHelperText("");
+                        } else {
+                            onChangeGraphId(event.target.value, false);
+                            setGraphIdErrorHelperText("Graph ID can only contain numbers and lowercase letters");
+                        }
+                    }}
+                />
+            </Grid>
+            <Grid item xs={12} container direction="row" justify="flex-end" alignItems="center"></Grid>
+            <Grid item xs={12}>
+                <InputLabel aria-label="graph-collaborator-input-label" id="graph-collaborator-input-label" required>
+                    Graph Collaborator
+                </InputLabel>
+                <TextField
+                    id="graph-collaborator"
+                    aria-label="graph-collaborator-input"
+                    inputProps={{
+                        name: "Graph Collaborator",
+                        id: "graph-collaborator-input",
+                        "aria-label": "graph-collaborator-input",
+                    }}
+                    value={collaboratorValue}
+                    error={collaboratorErrorHelperText.length > 0}
+                    required
+                    multiline
+                    autoFocus
+                    fullWidth
+                    name="graph-collaborator"
+                    variant="outlined"
+                    helperText={collaboratorErrorHelperText}
+                    onChange={(event) => {
+                        const regex = new RegExp("^[a-zA-Z0-9 ]*$");
+                        if (regex.test(event.target.value)) {
+                            onChangeCollaborator(event.target.value, true);
+                            setCollaboratorErrorHelperText("");
+                        } else {
+                            onChangeCollaborator(event.target.value, false);
+                            setCollaboratorErrorHelperText("Graph Collaborator can only contain numbers and letters");
+                        }
+                    }}
+                />
+            </Grid>
+        </>
+    );
+}

--- a/gaffer-as-a-service/gaas-ui/src/components/add-collaborator/graph-id-collaborator.tsx
+++ b/gaffer-as-a-service/gaas-ui/src/components/add-collaborator/graph-id-collaborator.tsx
@@ -21,15 +21,13 @@ import { InputLabel } from "@material-ui/core";
 
 interface IProps {
     graphIdValue: string;
-    collaboratorValue: string;
-    onChangeGraphId(graphId: string, graphIdIsValid: boolean): void;
-    onChangeCollaborator(graphId: string, graphCollaboratorIsValid: boolean): void;
+    usernameValue: string;
+    onChangeUsername(graphId: string, usernameIsValid: boolean): void;
 }
 
-export default function GraphIdCollaboratorInput(props: IProps): ReactElement {
-    const { graphIdValue, collaboratorValue, onChangeGraphId, onChangeCollaborator } = props;
-    const [graphIdErrorHelperText, setGraphIdErrorHelperText] = useState("");
-    const [collaboratorErrorHelperText, setCollaboratorErrorHelperText] = useState("");
+export default function GraphIdUsernameInput(props: IProps): ReactElement {
+    const { graphIdValue, usernameValue, onChangeUsername } = props;
+    const [usernameErrorHelperText, setUsernameErrorHelperText] = useState("");
 
     return (
         <>
@@ -39,62 +37,47 @@ export default function GraphIdCollaboratorInput(props: IProps): ReactElement {
                 </InputLabel>
                 <TextField
                     id="graph-id"
-                    inputProps={{
-                        name: "Graph ID",
-                        id: "graph-id-input",
-                        "aria-label": "graph-id-input",
-                    }}
                     aria-label="graph-id-input"
                     variant="outlined"
-                    value={graphIdValue}
-                    error={graphIdErrorHelperText.length > 0}
+                    value="testgraph"
                     required
                     fullWidth
                     autoFocus
-                    helperText={graphIdErrorHelperText}
                     name="graph-id"
-                    onChange={(event) => {
-                        const regex = new RegExp("^[a-z0-9]*$");
-                        if (regex.test(event.target.value)) {
-                            onChangeGraphId(event.target.value, true);
-                            setGraphIdErrorHelperText("");
-                        } else {
-                            onChangeGraphId(event.target.value, false);
-                            setGraphIdErrorHelperText("Graph ID can only contain numbers and lowercase letters");
-                        }
-                    }}
                 />
             </Grid>
             <Grid item xs={12} container direction="row" justify="flex-end" alignItems="center"></Grid>
             <Grid item xs={12}>
-                <InputLabel aria-label="graph-collaborator-input-label" id="graph-collaborator-input-label" required>
-                    Graph Collaborator
+                <InputLabel aria-label="username-input-label" id="username-input-label" required>
+                    User name
                 </InputLabel>
                 <TextField
-                    id="graph-collaborator"
-                    aria-label="graph-collaborator-input"
+                    id="username"
+                    aria-label="username-input"
                     inputProps={{
-                        name: "Graph Collaborator",
-                        id: "graph-collaborator-input",
-                        "aria-label": "graph-collaborator-input",
+                        name: "User Name",
+                        id: "username-input",
+                        "aria-label": "username-input",
                     }}
-                    value={collaboratorValue}
-                    error={collaboratorErrorHelperText.length > 0}
+                    value={usernameValue}
+                    error={usernameErrorHelperText.length > 0}
                     required
                     multiline
                     autoFocus
                     fullWidth
-                    name="graph-collaborator"
+                    name="username"
                     variant="outlined"
-                    helperText={collaboratorErrorHelperText}
+                    helperText={usernameErrorHelperText}
                     onChange={(event) => {
-                        const regex = new RegExp("^[a-zA-Z0-9 ]*$");
+                        const regex = new RegExp("^[ A-Za-z0-9_@.-]*$");
                         if (regex.test(event.target.value)) {
-                            onChangeCollaborator(event.target.value, true);
-                            setCollaboratorErrorHelperText("");
+                            onChangeUsername(event.target.value, true);
+                            setUsernameErrorHelperText("");
                         } else {
-                            onChangeCollaborator(event.target.value, false);
-                            setCollaboratorErrorHelperText("Graph Collaborator can only contain numbers and letters");
+                            onChangeUsername(event.target.value, false);
+                            setUsernameErrorHelperText(
+                                "User name can only contain alphanumeric and some special characters @ . - _"
+                            );
                         }
                     }}
                 />

--- a/gaffer-as-a-service/gaas-ui/src/components/navigation-bar/AppRoutes.tsx
+++ b/gaffer-as-a-service/gaas-ui/src/components/navigation-bar/AppRoutes.tsx
@@ -17,6 +17,7 @@
 import CreateGraph from "../create-graph/create-graph";
 import UserGuide from "../user-guide/user-guide";
 import ViewGraph from "../view-graphs/view-graphs";
+import AddCollaborator from "../add-collaborator/add-collaborator";
 
 const AppRoutes = [
     {
@@ -33,6 +34,11 @@ const AppRoutes = [
         path: "/userguide",
         sidebarName: "User Guide",
         component: UserGuide,
+    },
+    {
+        path: "/addcollaborator",
+        sidebarName: "",
+        component: AddCollaborator,
     },
 ];
 

--- a/gaffer-as-a-service/gaas-ui/src/components/view-graphs/view-graphs-table.tsx
+++ b/gaffer-as-a-service/gaas-ui/src/components/view-graphs/view-graphs-table.tsx
@@ -50,7 +50,6 @@ interface IProps {
     graphs: Graph[];
     federatedStores: Array<string>;
     deleteGraph: (graphName: string) => void;
-    addCollaborator: (graphId: string) => void;
     refreshTable: () => void;
 }
 
@@ -58,7 +57,6 @@ interface IGraphRow {
     index: number;
     graph: Graph;
     federatedStores: Array<string>;
-    onClickAddCollaborator: (graphId: string) => void;
     onClickDelete: (graphId: string) => void;
 }
 
@@ -100,7 +98,6 @@ export function ViewGraphsTable(props: IProps) {
                                     index={index}
                                     graph={graph}
                                     federatedStores={props.federatedStores}
-                                    onClickAddCollaborator={(graphId: string) => props.addCollaborator(graphId)}
                                     onClickDelete={(graphId: string) => props.deleteGraph(graphId)}
                                 />
                             ))}
@@ -142,7 +139,7 @@ function StatusChip(graph: { status: string }) {
 }
 
 function MainGraphTableRow(props: IGraphRow) {
-    const { graph, index, federatedStores, onClickDelete, onClickAddCollaborator } = props;
+    const { graph, index, federatedStores, onClickDelete } = props;
     const classes = useStyles();
     const [rowIsExpanded, setRowIsExpanded] = React.useState(false);
     const [allGraphIdsText, setAllGraphIdsText] = React.useState<string>("");

--- a/gaffer-as-a-service/gaas-ui/src/components/view-graphs/view-graphs-table.tsx
+++ b/gaffer-as-a-service/gaas-ui/src/components/view-graphs/view-graphs-table.tsx
@@ -42,12 +42,15 @@ import WarningRoundedIcon from "@material-ui/icons/WarningRounded";
 import KeyboardArrowUpIcon from "@material-ui/icons/KeyboardArrowUp";
 import KeyboardArrowDownIcon from "@material-ui/icons/KeyboardArrowDown";
 import DeleteOutlineOutlinedIcon from "@material-ui/icons/DeleteOutlineOutlined";
+import PersonAddOutlinedIcon from "@material-ui/icons/PersonAddOutlined";
 import { sanitizeUrl } from "@braintree/sanitize-url";
+import { useNavigate } from "react-router-dom";
 
 interface IProps {
     graphs: Graph[];
     federatedStores: Array<string>;
     deleteGraph: (graphName: string) => void;
+    addCollaborator: (graphId: string) => void;
     refreshTable: () => void;
 }
 
@@ -55,6 +58,7 @@ interface IGraphRow {
     index: number;
     graph: Graph;
     federatedStores: Array<string>;
+    onClickAddCollaborator: (graphId: string) => void;
     onClickDelete: (graphId: string) => void;
 }
 
@@ -85,6 +89,7 @@ export function ViewGraphsTable(props: IProps) {
                                 <TableCell>Status</TableCell>
                                 <TableCell>UI URL</TableCell>
                                 <TableCell>REST URL</TableCell>
+                                <TableCell>Add Collaborator</TableCell>
                                 <TableCell>Actions</TableCell>
                             </TableRow>
                         </TableHead>
@@ -95,6 +100,7 @@ export function ViewGraphsTable(props: IProps) {
                                     index={index}
                                     graph={graph}
                                     federatedStores={props.federatedStores}
+                                    onClickAddCollaborator={(graphId: string) => props.addCollaborator(graphId)}
                                     onClickDelete={(graphId: string) => props.deleteGraph(graphId)}
                                 />
                             ))}
@@ -136,10 +142,17 @@ function StatusChip(graph: { status: string }) {
 }
 
 function MainGraphTableRow(props: IGraphRow) {
-    const { graph, index, federatedStores, onClickDelete } = props;
+    const { graph, index, federatedStores, onClickDelete, onClickAddCollaborator } = props;
     const classes = useStyles();
     const [rowIsExpanded, setRowIsExpanded] = React.useState(false);
     const [allGraphIdsText, setAllGraphIdsText] = React.useState<string>("");
+
+    const navigate = useNavigate();
+
+    const navigateToAddcollaborator = () => {
+        // 👇️ navigate to /addcollaborator
+        navigate("/addcollaborator");
+    };
 
     useEffect(() => {
         setGraphUrl();
@@ -221,6 +234,17 @@ function MainGraphTableRow(props: IGraphRow) {
                     >
                         {graph.getRestUrl()}
                     </a>
+                </TableCell>
+                <TableCell aria-label={"add-collaborator"}>
+                    <Tooltip TransitionComponent={Zoom} title={`AddCollaborator ${graph.getId()}`}>
+                        <IconButton
+                            id={"add-collaborator-button-" + index}
+                            aria-label={graph.getId() + "-add-collaborator-button"}
+                            onClick={navigateToAddcollaborator}
+                        >
+                            <PersonAddOutlinedIcon />
+                        </IconButton>
+                    </Tooltip>
                 </TableCell>
                 <TableCell aria-label={"delete-graph"}>
                     <Tooltip TransitionComponent={Zoom} title={`Delete ${graph.getId()}`}>

--- a/gaffer-as-a-service/gaas-ui/src/components/view-graphs/view-graphs-table.tsx
+++ b/gaffer-as-a-service/gaas-ui/src/components/view-graphs/view-graphs-table.tsx
@@ -148,7 +148,7 @@ function MainGraphTableRow(props: IGraphRow) {
 
     const navigateToAddcollaborator = () => {
         // 👇️ navigate to /addcollaborator
-        navigate("/addcollaborator");
+        navigate("/addcollaborator", { state: { graphId: graph.getId() } });
     };
 
     useEffect(() => {

--- a/gaffer-as-a-service/gaas-ui/src/components/view-graphs/view-graphs-table.tsx
+++ b/gaffer-as-a-service/gaas-ui/src/components/view-graphs/view-graphs-table.tsx
@@ -58,6 +58,7 @@ interface IGraphRow {
     graph: Graph;
     federatedStores: Array<string>;
     onClickDelete: (graphId: string) => void;
+    onClickAddcollaborator: (graphId: string) => void;
 }
 
 const useStyles = makeStyles({
@@ -73,6 +74,12 @@ const useStyles = makeStyles({
 
 export function ViewGraphsTable(props: IProps) {
     const classes = useStyles();
+
+    const navigate = useNavigate();
+
+    const navigateToAddcollaborator = (graphId: string) => {
+        navigate("/addcollaborator", { state: { graphId: graphId } });
+    };
 
     return (
         <Grid container spacing={3}>
@@ -98,6 +105,7 @@ export function ViewGraphsTable(props: IProps) {
                                     index={index}
                                     graph={graph}
                                     federatedStores={props.federatedStores}
+                                    onClickAddcollaborator={(graphId: string) => navigateToAddcollaborator(graphId)}
                                     onClickDelete={(graphId: string) => props.deleteGraph(graphId)}
                                 />
                             ))}
@@ -139,17 +147,10 @@ function StatusChip(graph: { status: string }) {
 }
 
 function MainGraphTableRow(props: IGraphRow) {
-    const { graph, index, federatedStores, onClickDelete } = props;
+    const { graph, index, federatedStores, onClickDelete, onClickAddcollaborator } = props;
     const classes = useStyles();
     const [rowIsExpanded, setRowIsExpanded] = React.useState(false);
     const [allGraphIdsText, setAllGraphIdsText] = React.useState<string>("");
-
-    const navigate = useNavigate();
-
-    const navigateToAddcollaborator = () => {
-        // 👇️ navigate to /addcollaborator
-        navigate("/addcollaborator", { state: { graphId: graph.getId() } });
-    };
 
     useEffect(() => {
         setGraphUrl();
@@ -237,7 +238,7 @@ function MainGraphTableRow(props: IGraphRow) {
                         <IconButton
                             id={"add-collaborator-button-" + index}
                             aria-label={graph.getId() + "-add-collaborator-button"}
-                            onClick={navigateToAddcollaborator}
+                            onClick={() => onClickAddcollaborator(graph.getId())}
                         >
                             <PersonAddOutlinedIcon />
                         </IconButton>

--- a/gaffer-as-a-service/gaas-ui/src/components/view-graphs/view-graphs.tsx
+++ b/gaffer-as-a-service/gaas-ui/src/components/view-graphs/view-graphs.tsx
@@ -24,6 +24,7 @@ import { Copyright } from "../copyright/copyright";
 import Gauge from "./gauge";
 import { ViewGraphsTable } from "./view-graphs-table";
 import { GaaSAPIErrorResponse } from "../../rest/http-message-interfaces/error-response-interface";
+import { AddCollaboratorRepo } from "../../rest/repositories/add-collaborator-repo";
 
 interface IState {
     graphs: Graph[];
@@ -82,6 +83,18 @@ export default class ViewGraph extends React.Component<{}, IState> {
         } catch (e) {
             this.setState({
                 errorMessage: `Failed to delete graph "${graphName}". ${(e as GaaSAPIErrorResponse).title}: ${
+                    (e as GaaSAPIErrorResponse).detail
+                }`,
+            });
+        }
+    }
+
+    private async addCollaborator(graphId: string) {
+        try {
+            await new AddCollaboratorRepo().addCollaborator(graphId);
+        } catch (e) {
+            this.setState({
+                errorMessage: `Failed to add collaborator "${graphId}". ${(e as GaaSAPIErrorResponse).title}: ${
                     (e as GaaSAPIErrorResponse).detail
                 }`,
             });
@@ -168,6 +181,7 @@ export default class ViewGraph extends React.Component<{}, IState> {
                         graphs={this.state.graphs}
                         federatedStores={this.state.federatedStores}
                         deleteGraph={(graphName) => this.deleteGraph(graphName)}
+                        addCollaborator={(graphId) => this.addCollaborator(graphId)}
                         refreshTable={async () => await this.getGraphs()}
                     />
                     <Box pt={4}>

--- a/gaffer-as-a-service/gaas-ui/src/components/view-graphs/view-graphs.tsx
+++ b/gaffer-as-a-service/gaas-ui/src/components/view-graphs/view-graphs.tsx
@@ -24,7 +24,6 @@ import { Copyright } from "../copyright/copyright";
 import Gauge from "./gauge";
 import { ViewGraphsTable } from "./view-graphs-table";
 import { GaaSAPIErrorResponse } from "../../rest/http-message-interfaces/error-response-interface";
-import { AddCollaboratorRepo } from "../../rest/repositories/add-collaborator-repo";
 
 interface IState {
     graphs: Graph[];
@@ -83,18 +82,6 @@ export default class ViewGraph extends React.Component<{}, IState> {
         } catch (e) {
             this.setState({
                 errorMessage: `Failed to delete graph "${graphName}". ${(e as GaaSAPIErrorResponse).title}: ${
-                    (e as GaaSAPIErrorResponse).detail
-                }`,
-            });
-        }
-    }
-
-    private async addCollaborator(graphId: string) {
-        try {
-            await new AddCollaboratorRepo().addCollaborator(graphId);
-        } catch (e) {
-            this.setState({
-                errorMessage: `Failed to add collaborator "${graphId}". ${(e as GaaSAPIErrorResponse).title}: ${
                     (e as GaaSAPIErrorResponse).detail
                 }`,
             });
@@ -181,7 +168,6 @@ export default class ViewGraph extends React.Component<{}, IState> {
                         graphs={this.state.graphs}
                         federatedStores={this.state.federatedStores}
                         deleteGraph={(graphName) => this.deleteGraph(graphName)}
-                        addCollaborator={(graphId) => this.addCollaborator(graphId)}
                         refreshTable={async () => await this.getGraphs()}
                     />
                     <Box pt={4}>

--- a/gaffer-as-a-service/gaas-ui/src/rest/clients/rest-client.ts
+++ b/gaffer-as-a-service/gaas-ui/src/rest/clients/rest-client.ts
@@ -53,6 +53,10 @@ export class RestClient<T> {
         return this.methodSpec(this);
     }
 
+    public addCollaborator(): any {
+        return this.methodSpec(this);
+    }
+
     public baseUrl(baseURL: string): any {
         this.baseURL = baseURL;
         return this.methodSpec(this);
@@ -115,6 +119,11 @@ export class RestClient<T> {
         },
         storeTypes: () => {
             restClient.url = "/storetypes";
+            restClient.headers = AuthSidecarClient.setHeaders();
+            return restClient.executeSpec(restClient);
+        },
+        addCollaborator: () => {
+            restClient.url = "/addCollaborator";
             restClient.headers = AuthSidecarClient.setHeaders();
             return restClient.executeSpec(restClient);
         },

--- a/gaffer-as-a-service/gaas-ui/src/rest/http-message-interfaces/request-interfaces.ts
+++ b/gaffer-as-a-service/gaas-ui/src/rest/http-message-interfaces/request-interfaces.ts
@@ -30,3 +30,8 @@ export interface ICreateFederatedGraphRequestBody extends ICreateGraphInterface 
     proxySubGraphs: Array<{ graphId: string; host: string; root: string }>;
     configName: string;
 }
+
+export interface IAddCollaboratorInterface {
+    graphId: string;
+    collaborator: string;
+}

--- a/gaffer-as-a-service/gaas-ui/src/rest/http-message-interfaces/request-interfaces.ts
+++ b/gaffer-as-a-service/gaas-ui/src/rest/http-message-interfaces/request-interfaces.ts
@@ -33,5 +33,5 @@ export interface ICreateFederatedGraphRequestBody extends ICreateGraphInterface 
 
 export interface IAddCollaboratorInterface {
     graphId: string;
-    collaborator: string;
+    username: string;
 }

--- a/gaffer-as-a-service/gaas-ui/src/rest/repositories/add-collaborator-repo.ts
+++ b/gaffer-as-a-service/gaas-ui/src/rest/repositories/add-collaborator-repo.ts
@@ -19,10 +19,10 @@ import { IAddCollaboratorInterface } from "../http-message-interfaces/request-in
 import { Config } from "../config";
 
 export class AddCollaboratorRepo {
-    public async addCollaborator(graphId: string): Promise<void> {
+    public async addCollaborator(graphId: string, username: string): Promise<void> {
         const httpRequestBody: IAddCollaboratorInterface = {
             graphId: graphId,
-            collaborator: "test-gmail_com",
+            username: username,
         };
         await new RestClient()
             .baseUrl(Config.REACT_APP_KAI_REST_API_HOST)

--- a/gaffer-as-a-service/gaas-ui/src/rest/repositories/add-collaborator-repo.ts
+++ b/gaffer-as-a-service/gaas-ui/src/rest/repositories/add-collaborator-repo.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021-2022 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { RestClient } from "../clients/rest-client";
+import { IAddCollaboratorInterface } from "../http-message-interfaces/request-interfaces";
+import { Config } from "../config";
+
+export class AddCollaboratorRepo {
+    public async addCollaborator(graphId: string): Promise<void> {
+        const httpRequestBody: IAddCollaboratorInterface = {
+            graphId: graphId,
+            collaborator: "test-gmail_com",
+        };
+        await new RestClient()
+            .baseUrl(Config.REACT_APP_KAI_REST_API_HOST)
+            .post()
+            .requestBody(httpRequestBody)
+            .addCollaborator()
+            .execute();
+    }
+}

--- a/gaffer-as-a-service/gaas-ui/test/components/add-collaborator/add-collaborator.test.tsx
+++ b/gaffer-as-a-service/gaas-ui/test/components/add-collaborator/add-collaborator.test.tsx
@@ -18,7 +18,9 @@ import { mount, ReactWrapper } from "enzyme";
 import React from "react";
 import { act } from "react-dom/test-utils";
 import AddCcollaborator from "../../../src/components/add-collaborator/add-collaborator";
+import { AddCollaboratorRepo } from "../../../src/rest/repositories/add-collaborator-repo";
 
+jest.mock("../../../src/rest/repositories/add-collaborator-repo");
 jest.mock("react-router-dom", () => ({
     ...jest.requireActual("react-router-dom"),
     useLocation: () => ({ state: { graphId: "graphId" } }),
@@ -31,21 +33,70 @@ beforeEach(async () => {
 });
 
 afterEach(() => {
+    wrapper.unmount();
     jest.resetAllMocks();
 });
 
 describe("AddCollaborator UI component", () => {
     describe("Layout On Render", () => {
         it("Should have a Graph Id, username inputs", () => {
-            const graphIdTextfield = wrapper.find("input");
-            expect(graphIdTextfield.at(0).props().name).toBe("graph-id");
+            const graphId = wrapper.find("input#graph-id-input");
+            expect(graphId.props().value).toBe("graphId");
 
-            const usernameTextfield = wrapper.find("input");
-            expect(usernameTextfield.at(1).props().name).toBe("User Name");
+            const username = wrapper.find("input#username-input");
+            expect(username.props().name).toBe("User Name");
+        });
+
+        it("should capture username correctly onChange", () => {
+            const username = wrapper.find("input#username-input");
+            inputUsername("John");
+            // expect(graphId.props().value).toBe("John");
+            expect(username.instance().value).toBe("John");
+        });
+
+        it("should be disabled when username field is empty", () => {
+            inputUsername("");
+
+            expect(wrapper.find("button#add-collaborator-button").props().disabled).toBe(true);
         });
         it("should have a Submit button", () => {
             const submitButton = wrapper.find("button#add-collaborator-button").text();
             expect(submitButton).toBe("Add Collaborator");
         });
     });
+
+    describe("On Submit Request", () => {
+        it("should display success message in the NotificationAlert", async () => {
+            const mock = jest.fn();
+            mockAddCollaboratorRepoWithFunction(mock);
+            await inputUsername("John");
+            await wrapper.update();
+            await wrapper.update();
+            await clickSubmit();
+            await wrapper.update();
+            await wrapper.update();
+           expect(wrapper.find("div#notification-alert").text()).toBe("graphId was successfully added collaborator");
+            expect(mock).toHaveBeenLastCalledWith("graphId", "John");
+      
+        });
+    });
 });
+
+async function clickSubmit(): Promise<void> {
+    await act(async () => {
+        wrapper.find("button#add-collaborator-button").simulate("click");
+    });
+}
+
+function inputUsername(username: string): void {
+    wrapper.find("input#username-input").simulate("change", {
+        target: { value: username },
+    });
+}
+
+function mockAddCollaboratorRepoWithFunction(f: () => void): void {
+    // @ts-ignore
+    AddCollaboratorRepo.mockImplementationOnce(() => ({
+        addCollaborator: f,
+    }
+}

--- a/gaffer-as-a-service/gaas-ui/test/components/add-collaborator/add-collaborator.test.tsx
+++ b/gaffer-as-a-service/gaas-ui/test/components/add-collaborator/add-collaborator.test.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021-2022 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { mount, ReactWrapper } from "enzyme";
+import React from "react";
+import { act } from "react-dom/test-utils";
+import AddCcollaborator from "../../../src/components/add-collaborator/add-collaborator";
+
+jest.mock("react-router-dom", () => ({
+    ...jest.requireActual("react-router-dom"),
+    useLocation: () => ({ state: { graphId: "graphId" } }),
+}));
+
+let wrapper: ReactWrapper;
+
+beforeEach(async () => {
+    wrapper = mount(<AddCcollaborator />);
+});
+
+afterEach(() => {
+    jest.resetAllMocks();
+});
+
+describe("AddCollaborator UI component", () => {
+    describe("Layout On Render", () => {
+        it("Should have a Graph Id, username inputs", () => {
+            const graphIdTextfield = wrapper.find("input");
+            expect(graphIdTextfield.at(0).props().name).toBe("graph-id");
+
+            const usernameTextfield = wrapper.find("input");
+            expect(usernameTextfield.at(1).props().name).toBe("User Name");
+        });
+        it("should have a Submit button", () => {
+            const submitButton = wrapper.find("button#add-collaborator-button").text();
+            expect(submitButton).toBe("Add Collaborator");
+        });
+    });
+});

--- a/gaffer-as-a-service/gaas-ui/test/components/add-collaborator/graph-id-collaborator.test.tsx
+++ b/gaffer-as-a-service/gaas-ui/test/components/add-collaborator/graph-id-collaborator.test.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021-2022 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { mount, ReactWrapper } from "enzyme";
+import GraphIdUsernameInput from "../../../src/components/add-collaborator/graph-id-collaborator";
+import React from "react";
+
+const usernameMockCallBack = jest.fn();
+
+const component: ReactWrapper = mount(
+    <GraphIdUsernameInput
+        graphIdValue="display-id"
+        usernameValue="Inputted username here"
+        onChangeUsername={usernameMockCallBack}
+    />
+);
+
+afterEach(() => jest.resetAllMocks());
+
+describe("Graph ID & Username", () => {
+    it("should populate input value with usernameValue prop", () => {
+        expect(component.find("input#username-input").props().value).toBe("Inputted username here");
+    });
+
+    it("should call back with username and boolean when character inputted", () => {
+        component.find("input#username-input").simulate("change", {
+            target: { value: "id" },
+        });
+
+        expect(usernameMockCallBack).toHaveBeenLastCalledWith("id", true);
+    });
+    it("should display error message when invalid username entered", () => {
+        component.find("input#username-input").simulate("change", {
+            target: { value: "id+" },
+        });
+
+        expect(component.find("p#username-helper-text").text()).toBe(
+            "User name can only contain alphanumeric and some special characters @ . - _"
+        );
+    });
+});

--- a/gaffer-as-a-service/gaas-ui/test/components/add-collaborator/graph-id-collaborator.test.tsx
+++ b/gaffer-as-a-service/gaas-ui/test/components/add-collaborator/graph-id-collaborator.test.tsx
@@ -31,6 +31,10 @@ const component: ReactWrapper = mount(
 afterEach(() => jest.resetAllMocks());
 
 describe("Graph ID & Username", () => {
+    it("should populate input value with graphIdValue prop", () => {
+        expect(component.find("input").get(0).props.value).toEqual("display-id");
+    });
+
     it("should populate input value with usernameValue prop", () => {
         expect(component.find("input#username-input").props().value).toBe("Inputted username here");
     });

--- a/gaffer-as-a-service/gaas-ui/test/components/view-graphs/view-graphs.test.tsx
+++ b/gaffer-as-a-service/gaas-ui/test/components/view-graphs/view-graphs.test.tsx
@@ -31,6 +31,12 @@ jest.mock("../../../src/rest/repositories/delete-graph-repo");
 jest.mock("../../../src/rest/repositories/get-store-types-repo");
 jest.mock("../../../src/rest/repositories/gaffer/get-all-graph-ids-repo");
 
+const mockedUsedNavigate = jest.fn();
+jest.mock("react-router-dom", () => ({
+    ...jest.requireActual("react-router-dom"),
+    useNavigate: () => mockedUsedNavigate,
+}));
+
 afterEach(() => jest.resetAllMocks());
 
 describe("When ViewGraphs mounts", () => {
@@ -51,7 +57,7 @@ describe("When ViewGraphs mounts", () => {
         await component.update();
         await component.update();
 
-        expect(component.find("thead").text()).toBe("Graph IDStore TypeStatusUI URLREST URLActions");
+        expect(component.find("thead").text()).toBe("Graph IDStore TypeStatusUI URLREST URLAdd CollaboratorActions");
         expect(component.find("tbody").text()).toBe("testId1 MUPhttp://testId-1.app/uihttp://testId-1.app/rest");
         expect(component.find("caption").length).toBe(0);
     });

--- a/gaffer-as-a-service/gaas-ui/test/components/view-graphs/view-graphs.test.tsx
+++ b/gaffer-as-a-service/gaas-ui/test/components/view-graphs/view-graphs.test.tsx
@@ -59,7 +59,7 @@ describe("When ViewGraphs mounts", () => {
         await component.update();
 
         expect(component.find("thead").text()).toBe(
-            "Graph IDStore TypeStatusUI URLREST URLGraph Auto Destroy DateActionsAdd CollaboratorActions"
+            "Graph IDStore TypeStatusUI URLREST URLAdd CollaboratorGraph Auto Destroy DateActions"
         );
         expect(component.find("tbody").text()).toBe(
             "testId1 MUPhttp://testId-1.app/uihttp://testId-1.app/rest2022-06-09t15:55:34.006"

--- a/gaffer-as-a-service/pom.xml
+++ b/gaffer-as-a-service/pom.xml
@@ -38,7 +38,7 @@
     <properties>
         <kubernetes.version>14.0.0</kubernetes.version>
         <springboot.version>2.6.5</springboot.version>
-        <fasterxml.jackson.version>2.9.8</fasterxml.jackson.version>
+        <fasterxml.jackson.version>2.13.3</fasterxml.jackson.version>
         <javax.xml.bind.version>2.3.0</javax.xml.bind.version>
         <junit.version>5.7.0</junit.version>
         <apache.commons.text.version>1.9</apache.commons.text.version>


### PR DESCRIPTION
Add a new endpoint which handles adding a new label with the username of the user who is being given permission to view the graph. This endpoint should perform a helm upgrade install and simply add a new label e.g a 'readers' label with the value being the username of the user who is being given permission.

Acceptence criteria 
- On view graphs page in the graphs column each graph should have an add collaborator button
-Page allows user to enter the username of the collaborator for the chosen graph (graphId)
-Submission sends request to /addCollaborator graph endpoint