### PR TITLE
add patch to role binding

### DIFF
--- a/gaffer-as-a-service/deploy/helm/charts/gaas-rest/templates/role-binding.yaml
+++ b/gaffer-as-a-service/deploy/helm/charts/gaas-rest/templates/role-binding.yaml
@@ -22,7 +22,7 @@ rules:
     verbs: ["create", "patch", "list", "get", "delete"]
   - apiGroups: ["apps"]
     resources: ["deployments"]
-    verbs: ["list", "get", "delete", "create"]
+    verbs: ["list", "get", "delete", "create", "patch"]
 ---
 
 kind: RoleBinding


### PR DESCRIPTION
1 change in this PR which simply adds `patch` permissions to the service account assigned to gaas-rest to enable the add-collaborators functionality to work.

This should have been in #336 sorry